### PR TITLE
Service: Initialize helper

### DIFF
--- a/ayon_api/__init__.py
+++ b/ayon_api/__init__.py
@@ -7,6 +7,9 @@ from .server import (
 
 from .server_api import (
     ServerAPI,
+    ServiceContext,
+
+    init_service,
 
     get_server_api_connection,
 
@@ -103,6 +106,8 @@ __all__ = (
     "ServerAPIBase",
 
     "ServerAPI",
+    "ServiceContext",
+    "init_service",
 
     "get_server_api_connection",
 

--- a/ayon_api/exceptions.py
+++ b/ayon_api/exceptions.py
@@ -91,3 +91,7 @@ class FolderNotFound(MissingEntityError):
 
 class FailedOperations(Exception):
     pass
+
+
+class FailedServiceInit(Exception):
+    pass


### PR DESCRIPTION
## Description
Added Service helper class with context about running service which is launched from server. Service just have to call 'init_service' on start of process.

## Detailed description
This has no effect on server connection api it just helps to receive information from environments and create connection. Logic was copied from `ayclient` (premature server api for services).