### PR TITLE
Make generator functions compatible with Py2

### DIFF
--- a/ayon_api/server.py
+++ b/ayon_api/server.py
@@ -1287,7 +1287,7 @@ class ServerAPIBase(object):
                 returned if 'None' is passed.
 
         Returns:
-            List[Dict[str, Any]]: List of available projects.
+            Generator[Dict[str, Any]]: Available projects.
         """
 
         for project_name in self.get_project_names(active, library):
@@ -1375,7 +1375,7 @@ class ServerAPIBase(object):
                 on entity will have 'None' value.
 
         Returns:
-            List[Dict[str, Any]]: List of queried projects.
+            Generator[Dict[str, Any]]: Queried projects.
         """
 
         if fields is None:
@@ -1484,11 +1484,11 @@ class ServerAPIBase(object):
                 if 'None' is passed.
 
         Returns:
-            Iterable[dict[str, Any]]: Queried folder entities.
+            Generator[dict[str, Any]]: Queried folder entities.
         """
 
         if not project_name:
-            return []
+            return
 
         filters = {
             "projectName": project_name
@@ -1496,25 +1496,25 @@ class ServerAPIBase(object):
         if folder_ids is not None:
             folder_ids = set(folder_ids)
             if not folder_ids:
-                return []
+                return
             filters["folderIds"] = list(folder_ids)
 
         if folder_paths is not None:
             folder_paths = set(folder_paths)
             if not folder_paths:
-                return []
+                return
             filters["folderPaths"] = list(folder_paths)
 
         if folder_names is not None:
             folder_names = set(folder_names)
             if not folder_names:
-                return []
+                return
             filters["folderNames"] = list(folder_names)
 
         if parent_ids is not None:
             parent_ids = set(parent_ids)
             if not parent_ids:
-                return []
+                return
             if None in parent_ids:
                 # Replace 'None' with '"root"' which is used during GraphQl
                 #   query for parent ids filter for folders without folder
@@ -1575,7 +1575,7 @@ class ServerAPIBase(object):
         own_attributes=False
     ):
         if not project_name:
-            return []
+            return
 
         filters = {
             "projectName": project_name
@@ -1584,25 +1584,25 @@ class ServerAPIBase(object):
         if task_ids is not None:
             task_ids = set(task_ids)
             if not task_ids:
-                return []
+                return
             filters["taskIds"] = list(task_ids)
 
         if task_names is not None:
             task_names = set(task_names)
             if not task_names:
-                return []
+                return
             filters["taskNames"] = list(task_names)
 
         if task_types is not None:
             task_types = set(task_types)
             if not task_types:
-                return []
+                return
             filters["taskTypes"] = list(task_types)
 
         if folder_ids is not None:
             folder_ids = set(folder_ids)
             if not folder_ids:
-                return []
+                return
             filters["folderIds"] = list(folder_ids)
 
         if not fields:
@@ -1772,24 +1772,24 @@ class ServerAPIBase(object):
         own_attributes=False
     ):
         if not project_name:
-            return []
+            return
 
         if subset_ids is not None:
             subset_ids = set(subset_ids)
             if not subset_ids:
-                return []
+                return
 
         filter_subset_names = None
         if subset_names is not None:
             filter_subset_names = set(subset_names)
             if not filter_subset_names:
-                return []
+                return
 
         filter_folder_ids = None
         if folder_ids is not None:
             filter_folder_ids = set(folder_ids)
             if not filter_folder_ids:
-                return []
+                return
 
         # This will disable 'folder_ids' and 'subset_names' filters
         #   - maybe could be enhanced in future?
@@ -1803,7 +1803,7 @@ class ServerAPIBase(object):
                     filter_subset_names |= set(names)
 
             if not filter_subset_names or not filter_folder_ids:
-                return []
+                return
 
         # Convert fields and add minimum required fields
         if fields:
@@ -1972,7 +1972,7 @@ class ServerAPIBase(object):
                 if 'None' is passed.
 
         Returns:
-            List[Dict[str, Any]]: Queried version entities.
+            Generator[Dict[str, Any]]: Queried version entities.
         """
 
         if not fields:
@@ -1999,24 +1999,24 @@ class ServerAPIBase(object):
         if version_ids is not None:
             version_ids = set(version_ids)
             if not version_ids:
-                return []
+                return
             filters["versionIds"] = list(version_ids)
 
         if subset_ids is not None:
             subset_ids = set(subset_ids)
             if not subset_ids:
-                return []
+                return
             filters["subsetIds"] = list(subset_ids)
 
         # TODO versions can't be used as fitler at this moment!
         if versions is not None:
             versions = set(versions)
             if not versions:
-                return []
+                return
             filters["versions"] = list(versions)
 
         if not hero and not standard:
-            return []
+            return
 
         queries = []
         # Add filters based on 'hero' and 'standard'
@@ -2285,7 +2285,7 @@ class ServerAPIBase(object):
                 passed.
 
         Returns:
-            List[Dict[str, Any]]: Queried representation entities.
+            Generator[Dict[str, Any]]: Queried representation entities.
         """
 
         if not fields:
@@ -2310,7 +2310,7 @@ class ServerAPIBase(object):
         if representation_ids is not None:
             representation_ids = set(representation_ids)
             if not representation_ids:
-                return []
+                return
             filters["representationIds"] = list(representation_ids)
 
         version_ids_filter = None
@@ -2323,18 +2323,18 @@ class ServerAPIBase(object):
                 representaion_names_filter |= set(names)
 
             if not version_ids_filter or not representaion_names_filter:
-                return []
+                return
 
         else:
             if representation_names is not None:
                 representaion_names_filter = set(representation_names)
                 if not representaion_names_filter:
-                    return []
+                    return
 
             if version_ids is not None:
                 version_ids_filter = set(version_ids)
                 if not version_ids_filter:
-                    return []
+                    return
 
         if version_ids_filter:
             filters["versionIds"] = list(version_ids_filter)
@@ -2459,19 +2459,19 @@ class ServerAPIBase(object):
         if task_ids is not None:
             task_ids = set(task_ids)
             if not task_ids:
-                return []
+                return
             filters["taskIds"] = list(task_ids)
 
         if paths is not None:
             paths = set(paths)
             if not paths:
-                return []
+                return
             filters["paths"] = list(paths)
 
         if workfile_ids is not None:
             workfile_ids = set(workfile_ids)
             if not workfile_ids:
-                return []
+                return
             filters["workfileIds"] = list(workfile_ids)
 
         if not fields:

--- a/ayon_api/server.py
+++ b/ayon_api/server.py
@@ -1760,6 +1760,20 @@ class ServerAPIBase(object):
             for folder in folders
         }
 
+    def _filter_subset(
+        self, project_name, subset, active, own_attributes, use_rest
+    ):
+        if active is not None and subset["active"] is not active:
+            return None
+
+        if use_rest:
+            subset = self.get_rest_subset(project_name, subset["id"])
+
+        if own_attributes:
+            fill_own_attribs(subset)
+
+        return subset
+
     def get_subsets(
         self,
         project_name,
@@ -1847,35 +1861,30 @@ class ServerAPIBase(object):
         parsed_data = query.query(self)
 
         subsets = parsed_data.get("project", {}).get("subsets", [])
-        if active is not None or own_attributes:
-            _subsets = []
-            for subset in subsets:
-                if active is not None and subset["active"] is not active:
-                    continue
-
-                if use_rest:
-                    subset = self.get_rest_subset(project_name, subset["id"])
-
-                if own_attributes:
-                    fill_own_attribs(subset)
-                _subsets.append(subset)
-            subsets = _subsets
-
         # Filter subsets by 'names_by_folder_ids'
         if names_by_folder_ids:
             subsets_by_folder_id = collections.defaultdict(list)
             for subset in subsets:
-                folder_id = subset["folderId"]
-                subsets_by_folder_id[folder_id].append(subset)
+                filtered_subset = self._filter_subset(
+                    project_name, subset, active, own_attributes, use_rest
+                )
+                if filtered_subset is not None:
+                    folder_id = filtered_subset["folderId"]
+                    subsets_by_folder_id[folder_id].append(filtered_subset)
 
-            filtered_subsets = []
             for folder_id, names in names_by_folder_ids.items():
                 for folder_subset in subsets_by_folder_id[folder_id]:
                     if folder_subset["name"] in names:
-                        filtered_subsets.append(subset)
-            subsets = filtered_subsets
+                        yield folder_subset
 
-        return list(subsets)
+        else:
+            for subset in subsets:
+                filtered_subset = self._filter_subset(
+                    project_name, subset, active, own_attributes, use_rest
+                )
+                if filtered_subset is not None:
+                    yield filtered_subset
+
 
     def get_subset_by_id(
         self,

--- a/ayon_api/version.py
+++ b/ayon_api/version.py
@@ -1,2 +1,2 @@
 """Package declaring Python API for Ayon server."""
-__version__ = "0.1.8"
+__version__ = "0.1.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ayon_api"
-version = "0.1.8"
+version = "0.1.9"
 description = "Python api for AYON server"
 authors = ["ynput.io <info@ynput.io>"]
 


### PR DESCRIPTION
## Description
Generator functions returned empty list which is invalid which in Py3 it silently continue but in Py2 cause SyntaxError. This has been changed to just return which is Py2 and Py3 compatible way how to stop generator.