### PR TITLE
Handle RestApiResponse code 204

### DIFF
--- a/ayon_api/server.py
+++ b/ayon_api/server.py
@@ -95,7 +95,10 @@ class RestApiResponse(object):
     @property
     def data(self):
         if self._data is None:
-            self._data = self._response.json()
+            if self.status != 204:
+                self._data = self.orig_response.json()
+            else:
+                self._data = {}
         return self._data
 
     @property


### PR DESCRIPTION
The `204 No Content` response has no text, so it was tripping the `response.json()` invocation for the `patch` calls.