### PR TITLE
Refactor: Api names

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,8 @@ AYON Python api should support connection to server with raw REST functions and 
 Module support singleton connection which is using `AYON_SERVER_URL` and `AYON_TOKEN` environment variables as source for connection. The singleton connection is using `ServerAPI` object. There can be created multiple connection to different server at one time, for that purpose use `ServerAPIBase` object. 
 
 ## TODOs
-- More clear what is difference in `ServerAPIBase` and `ServerAPI` (`server.py` and `server_api.py`) and better names
-    - `ServerAPI` was added primarily for desktop app which handle login and logout in a different way so the class should be maybe removed and `ServerAPIBase` should be renamed to `ServerAPI`
-    - find more suitable names of classes
-    - find more suitable name of objects (right now is used `connection` or `con`)
+- Find more suitable name for objects of `ServerAPI` (right now is used `connection` or `con`)
 - Add folder and task changes to operations
   - Entity hub should use operations to update folders and tasks 
+- Add option to use machine id in connection
   

--- a/ayon_api/__init__.py
+++ b/ayon_api/__init__.py
@@ -6,7 +6,7 @@ from .server import (
     ServerAPI,
 )
 
-from .server_api import (
+from ._api import (
     GlobalServerAPI,
     ServiceContext,
 

--- a/ayon_api/__init__.py
+++ b/ayon_api/__init__.py
@@ -7,7 +7,7 @@ from .server import (
 )
 
 from .server_api import (
-    ServerAPI,
+    GlobalServerAPI,
     ServiceContext,
 
     init_service,
@@ -118,6 +118,8 @@ __all__ = (
     "ServerAPIBase",
 
     "ServerAPI",
+
+    "GlobalServerAPI",
     "ServiceContext",
     "init_service",
 

--- a/ayon_api/__init__.py
+++ b/ayon_api/__init__.py
@@ -3,7 +3,7 @@ from .utils import (
     slugify_string,
 )
 from .server import (
-    ServerAPIBase,
+    ServerAPI,
 )
 
 from .server_api import (
@@ -114,8 +114,6 @@ from .server_api import (
 __all__ = (
     "TransferProgress",
     "slugify_string",
-
-    "ServerAPIBase",
 
     "ServerAPI",
 

--- a/ayon_api/__init__.py
+++ b/ayon_api/__init__.py
@@ -2,7 +2,7 @@ from .utils import (
     TransferProgress,
     slugify_string,
 )
-from .server import (
+from .server_api import (
     ServerAPI,
 )
 

--- a/ayon_api/_api.py
+++ b/ayon_api/_api.py
@@ -1,3 +1,11 @@
+"""Singleton based server api for direct access.
+
+This implementation will be probably the most used part of package. Gives
+option to have singleton connection to Server URL based on environment variable
+values. All public functions and classes are imported in '__init__.py' so
+they're available directly in top module import.
+"""
+
 import os
 import socket
 
@@ -5,7 +13,7 @@ from .constants import (
     SERVER_URL_ENV_KEY,
     SERVER_TOKEN_ENV_KEY,
 )
-from .server import ServerAPI
+from .server_api import ServerAPI
 from .exceptions import FailedServiceInit
 
 

--- a/ayon_api/entity_hub.py
+++ b/ayon_api/entity_hub.py
@@ -27,7 +27,7 @@ class EntityHub(object):
 
     Args:
         project_name (str): Name of project where changes will happen.
-        connection (ServerAPIBase): Connection to server with logged user.
+        connection (ServerAPI): Connection to server with logged user.
         allow_data_changes (bool): This option gives ability to change 'data'
             key on entities. This is not recommended as 'data' may be use for
             secure information and would also slow down server queries. Content

--- a/ayon_api/entity_hub.py
+++ b/ayon_api/entity_hub.py
@@ -3,7 +3,7 @@ import collections
 from abc import ABCMeta, abstractmethod, abstractproperty
 
 import six
-from .server_api import get_server_api_connection
+from ._api import get_server_api_connection
 from .utils import create_entity_id, convert_entity_id
 
 UNKNOWN_VALUE = object()

--- a/ayon_api/events.py
+++ b/ayon_api/events.py
@@ -6,7 +6,7 @@ class ServerEvent(object):
         self,
         topic,
         sender=None,
-        hash=None,
+        event_hash=None,
         project_name=None,
         username=None,
         dependencies=None,
@@ -25,10 +25,11 @@ class ServerEvent(object):
 
         self.topic = topic
         self.sender = sender
-        self.hash = hash
+        self.event_hash = event_hash
         self.project_name = project_name
         self.username = username
         self.dependencies = dependencies
+        self.description = description
         self.summary = summary
         self.payload = payload
         self.finished = finished
@@ -38,10 +39,11 @@ class ServerEvent(object):
         return {
             "topic": self.topic,
             "sender": self.sender,
-            "hash": self.hash,
+            "hash": self.event_hash,
             "project": self.project_name,
             "user": self.username,
             "dependencies": copy.deepcopy(self.dependencies),
+            "description": self.description,
             "description": self.description,
             "summary": copy.deepcopy(self.summary),
             "payload": self.payload,

--- a/ayon_api/events.py
+++ b/ayon_api/events.py
@@ -1,5 +1,4 @@
 import copy
-from ._api import get_server_api_connection
 
 
 class ServerEvent(object):
@@ -49,56 +48,3 @@ class ServerEvent(object):
             "finished": self.finished,
             "store": self.store
         }
-
-
-def dispatch_event(
-    topic,
-    sender=None,
-    hash=None,
-    project_name=None,
-    username=None,
-    dependencies=None,
-    description=None,
-    summary=None,
-    payload=None,
-    finished=True,
-    store=True,
-):
-    """Dispatch event to server.
-
-    Arg:
-        topic (str): Event topic used for filtering of listeners.
-        sender (Optional[str]): Sender of event.
-        hash (Optional[str]): Event hash.
-        project_name (Optional[str]): Project name.
-        username (Optional[str]): Username which triggered event.
-        dependencies (Optional[list[str]]): List of event id deprendencies.
-        description (Optional[str]): Description of event.
-        summary (Optional[dict[str, Any]]): Summary of event that can be used
-            for simple filtering on listeners.
-        payload (Optional[dict[str, Any]]): Full payload of event data with
-            all details.
-        finished (bool): Mark event as finished on dispatch.
-        store (bool): Store event in event queue for possible future processing
-            otherwise is event send only to active listeners.
-    """
-
-    event = ServerEvent(
-        topic,
-        sender,
-        hash,
-        project_name,
-        username,
-        dependencies,
-        description,
-        summary,
-        payload,
-        finished,
-        store
-    )
-    con = get_server_api_connection()
-    response = con.post("events", json=event.to_data())
-    if response:
-        print(response, response.data)
-        return event
-    return None

--- a/ayon_api/events.py
+++ b/ayon_api/events.py
@@ -1,6 +1,5 @@
 import copy
-
-from .server_api import get_server_api_connection
+from ._api import get_server_api_connection
 
 
 class ServerEvent(object):

--- a/ayon_api/operations.py
+++ b/ayon_api/operations.py
@@ -6,7 +6,7 @@ from abc import ABCMeta, abstractproperty
 
 import six
 
-from .server_api import get_server_api_connection
+from ._api import get_server_api_connection
 from .utils import create_entity_id, REMOVED_VALUE
 
 

--- a/ayon_api/server.py
+++ b/ayon_api/server.py
@@ -186,7 +186,7 @@ def fill_own_attribs(entity):
             own_attrib[key] = copy.deepcopy(value)
 
 
-class ServerAPIBase(object):
+class ServerAPI(object):
     """Base handler of connection to server.
 
     Requires url to server which is used as base for api and graphql calls.

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -5,11 +5,11 @@ from .constants import (
     SERVER_URL_ENV_KEY,
     SERVER_TOKEN_ENV_KEY,
 )
-from .server import ServerAPIBase
+from .server import ServerAPI
 from .exceptions import FailedServiceInit
 
 
-class GlobalServerAPI(ServerAPIBase):
+class GlobalServerAPI(ServerAPI):
     """Extended server api which also handles storing tokens and url.
 
     Created object expect to have set environment variables

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -709,6 +709,25 @@ class ServerAPI(object):
         finished=True,
         store=True,
     ):
+        """Dispatch event to server.
+
+        Arg:
+            topic (str): Event topic used for filtering of listeners.
+            sender (Optional[str]): Sender of event.
+            hash (Optional[str]): Event hash.
+            project_name (Optional[str]): Project name.
+            username (Optional[str]): Username which triggered event.
+            dependencies (Optional[list[str]]): List of event id deprendencies.
+            description (Optional[str]): Description of event.
+            summary (Optional[dict[str, Any]]): Summary of event that can be used
+                for simple filtering on listeners.
+            payload (Optional[dict[str, Any]]): Full payload of event data with
+                all details.
+            finished (bool): Mark event as finished on dispatch.
+            store (bool): Store event in event queue for possible future processing
+                otherwise is event send only to active listeners.
+        """
+
         if summary is None:
             summary = {}
         if payload is None:

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -9,7 +9,7 @@ from .server import ServerAPIBase
 from .exceptions import FailedServiceInit
 
 
-class ServerAPI(ServerAPIBase):
+class GlobalServerAPI(ServerAPIBase):
     """Extended server api which also handles storing tokens and url.
 
     Created object expect to have set environment variables
@@ -21,7 +21,7 @@ class ServerAPI(ServerAPIBase):
         url = self.get_url()
         token = self.get_token()
 
-        super(ServerAPI, self).__init__(url, token)
+        super(GlobalServerAPI, self).__init__(url, token)
 
         self.validate_server_availability()
         self.create_session()
@@ -34,7 +34,7 @@ class ServerAPI(ServerAPIBase):
         """
 
         previous_token = self._access_token
-        super(ServerAPI, self).login(username, password)
+        super(GlobalServerAPI, self).login(username, password)
         if self.has_valid_token and previous_token != self._access_token:
             os.environ[SERVER_TOKEN_ENV_KEY] = self._access_token
 
@@ -74,7 +74,7 @@ class GlobalContext:
 
     @classmethod
     def change_token(cls, url, token):
-        ServerAPI.set_environments(url, token)
+        GlobalServerAPI.set_environments(url, token)
         if cls._connection is None:
             return
 
@@ -92,7 +92,7 @@ class GlobalContext:
     @classmethod
     def get_server_api_connection(cls):
         if cls._connection is None:
-            cls._connection = ServerAPI()
+            cls._connection = GlobalServerAPI()
         return cls._connection
 
 
@@ -170,8 +170,8 @@ class ServiceContext:
         cls.addon_version = addon_version
         cls.service_name = service_name or socket.gethostname()
 
-        # Make sure required environments for ServerAPI are set
-        ServerAPI.set_environments(cls.server_url, cls.token)
+        # Make sure required environments for GlobalServerAPI are set
+        GlobalServerAPI.set_environments(cls.server_url, cls.token)
 
         if connect:
             print("Connecting to server \"{}\"".format(server_url))
@@ -221,17 +221,17 @@ def set_environments(url, token):
         token (Union[str, None]): API key token to be used for connection.
     """
 
-    ServerAPI.set_environments(url, token)
+    GlobalServerAPI.set_environments(url, token)
 
 
 def get_server_api_connection():
-    """Access to global scope object of ServerAPI.
+    """Access to global scope object of GlobalServerAPI.
 
     This access expect to have set environment variables 'AYON_SERVER_URL'
     and 'AYON_TOKEN'.
 
     Returns:
-        ServerAPI: Object of connection to server.
+        GlobalServerAPI: Object of connection to server.
     """
 
     return GlobalContext.get_server_api_connection()


### PR DESCRIPTION
## Description
Enhance api names in the codebase. Renamed `ServerAPI` -> `GlobalServerAPI` and `ServerAPIBase` -> `ServerAPI`. Also were renamed files `server_api.py` -> `_api.py` and `server.py` -> `server_api.py`. These changes should cleanup api of the module as all global functions is in private file `_api.py` and are propagated to `__init__.py` so it's clear they're added just for api purposes but are not public from place where their implementation is.

### Side product
Removed unused `dispatch_event` function from `events.py`.