### PR TITLE
Added support to behave 'as user' and change global con args

### DIFF
--- a/ayon_api/__init__.py
+++ b/ayon_api/__init__.py
@@ -13,6 +13,7 @@ from .server_api import (
     init_service,
 
     is_connection_created,
+    create_connection,
     close_connection,
     change_token,
     set_environments,
@@ -122,6 +123,7 @@ __all__ = (
     "init_service",
 
     "is_connection_created",
+    "create_connection",
     "close_connection",
     "change_token",
     "set_environments",

--- a/ayon_api/__init__.py
+++ b/ayon_api/__init__.py
@@ -18,6 +18,8 @@ from .server_api import (
     change_token,
     set_environments,
     get_server_api_connection,
+    set_site_id,
+    set_client_version,
 
     get_base_url,
     get_rest_url,
@@ -128,6 +130,8 @@ __all__ = (
     "change_token",
     "set_environments",
     "get_server_api_connection",
+    "set_site_id",
+    "set_client_version",
 
     "get_base_url",
     "get_rest_url",

--- a/ayon_api/server.py
+++ b/ayon_api/server.py
@@ -362,6 +362,34 @@ class ServerAPIBase(object):
 
     site_id = property(get_site_id, set_site_id)
 
+    def get_client_version(self):
+        """Version of client used to connect to server.
+
+        Client version is AYON client build desktop application.
+
+        Returns:
+            str: Client version string used in connection.
+        """
+
+        return self._client_version
+
+    def set_client_version(self, client_version):
+        """Set version of client used to connect to server.
+
+        Client version is AYON client build desktop application.
+
+        Args:
+            client_version (Union[str, None]): Client version string.
+        """
+
+        if self._client_version == client_version:
+            return
+
+        self._client_version = client_version
+        self._update_session_headers()
+
+    client_version = property(get_client_version, set_client_version)
+
     def get_default_service_username(self):
         """Default username used for callbacks when used with service API key.
 

--- a/ayon_api/server.py
+++ b/ayon_api/server.py
@@ -222,9 +222,6 @@ class _AsUserStack:
         self._last_user = None
         self._default_user = None
 
-    def __bool__(self):
-        return self.username is not None
-
     def clear(self):
         self._users_by_id = {}
         self._user_ids = []

--- a/ayon_api/server.py
+++ b/ayon_api/server.py
@@ -537,6 +537,21 @@ class ServerAPIBase(object):
         self._session_functions_mapping = {}
         session.close()
 
+    def _update_session_headers(self):
+        if self._session is None:
+            return
+
+        # Header keys that may change over time
+        for key, value in (
+            ("X-as-user", self._as_user_stack.username),
+            ("x-ayon-version", self._client_version),
+            ("x-ayon-site-id", self._site_id),
+        ):
+            if value is not None:
+                self._session.headers[key] = value
+            elif key in self._session.headers:
+                self._session.headers.pop(key)
+
     def get_info(self):
         """Get information about current used api key.
 
@@ -592,21 +607,6 @@ class ServerAPIBase(object):
         if output is None:
             raise UnauthorizedError("User is not authorized.")
         return output
-
-    def _update_session_headers(self):
-        if self._session is None:
-            return
-
-        # Header keys that may change over time
-        for key, value in (
-            ("X-as-user", self._as_user_stack.username),
-            ("x-ayon-version", self._client_version),
-            ("x-ayon-site-id", self._site_id),
-        ):
-            if value is not None:
-                self._session.headers[key] = value
-            elif key in self._session.headers:
-                self._session.headers.pop(key)
 
     def get_headers(self, content_type=None):
         if content_type is None:

--- a/ayon_api/server.py
+++ b/ayon_api/server.py
@@ -328,6 +328,7 @@ class ServerAPIBase(object):
         self._attributes_schema = None
         self._entity_type_attributes_cache = {}
 
+        self._as_user_stack = _AsUserStack()
         self._thumbnail_cache = ThumbnailCache(True)
 
     def get_base_url(self):
@@ -406,6 +407,7 @@ class ServerAPIBase(object):
         if self._session is not None:
             raise ValueError("Session is already created.")
 
+        self._as_user_stack.clear()
         # Validate token before session creation
         self.validate_token()
 
@@ -510,6 +512,9 @@ class ServerAPIBase(object):
         if self._access_token:
             if self._access_token_is_service:
                 headers["X-Api-Key"] = self._access_token
+                username = self._as_user_stack.username
+                if username:
+                    headers["X-as-user"] = username
             else:
                 headers["Authorization"] = "Bearer {}".format(
                     self._access_token)

--- a/ayon_api/server.py
+++ b/ayon_api/server.py
@@ -331,6 +331,12 @@ class ServerAPIBase(object):
         self._as_user_stack = _AsUserStack()
         self._thumbnail_cache = ThumbnailCache(True)
 
+    @property
+    def log(self):
+        if self._log is None:
+            self._log = logging.getLogger(self.__class__.__name__)
+        return self._log
+
     def get_base_url(self):
         return self._base_url
 
@@ -487,12 +493,6 @@ class ServerAPIBase(object):
         if output is None:
             raise UnauthorizedError("User is not authorized.")
         return output
-
-    @property
-    def log(self):
-        if self._log is None:
-            self._log = logging.getLogger(self.__class__.__name__)
-        return self._log
 
     def get_headers(self, content_type=None):
         if content_type is None:

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -254,6 +254,32 @@ def get_server_api_connection():
     return GlobalContext.get_server_api_connection()
 
 
+def set_site_id(site_id):
+    """Set site id of already connected client connection.
+
+    Site id is human-readable machine id used in AYON desktop application.
+
+    Args:
+        site_id (Union[str, None]): Site id used in connection.
+    """
+
+    con = get_server_api_connection()
+    con.set_site_id(site_id)
+
+
+def set_client_version(client_version):
+    """Set version of already connected client connection.
+
+    Client version is version of AYON desktop application.
+
+    Args:
+        client_version (Union[str, None]): Client version string.
+    """
+
+    con = get_server_api_connection()
+    con.set_client_version(client_version)
+
+
 def get_base_url():
     con = get_server_api_connection()
     return con.get_base_url()

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -94,6 +94,7 @@ class GlobalContext:
         if cls._connection is not None:
             cls.close_connection()
         cls._connection = ServerAPI(*args, **kwargs)
+        return cls._connection
 
     @classmethod
     def get_server_api_connection(cls):
@@ -206,9 +207,12 @@ def create_connection(site_id=None, client_version=None):
     Args:
         site_id (str): Machine site id/name.
         client_version (str): Desktop app version.
+
+    Returns:
+        ServerAPI: Created connection.
     """
 
-    GlobalContext.create_connection(site_id, client_version)
+    return GlobalContext.create_connection(site_id, client_version)
 
 
 def close_connection():

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -17,11 +17,11 @@ class ServerAPI(ServerAPIBase):
     but that can be filled afterwards with calling 'login' method.
     """
 
-    def __init__(self):
+    def __init__(self, site_id=None, client_version=None):
         url = self.get_url()
         token = self.get_token()
 
-        super(ServerAPI, self).__init__(url, token)
+        super(ServerAPI, self).__init__(url, token, site_id, client_version)
 
         self.validate_server_availability()
         self.create_session()
@@ -90,9 +90,15 @@ class GlobalContext:
         cls._connection = None
 
     @classmethod
+    def create_connection(cls, *args, **kwargs):
+        if cls._connection is not None:
+            cls.close_connection()
+        cls._connection = ServerAPI(*args, **kwargs)
+
+    @classmethod
     def get_server_api_connection(cls):
         if cls._connection is None:
-            cls._connection = ServerAPI()
+            cls.create_connection()
         return cls._connection
 
 
@@ -192,6 +198,17 @@ def is_connection_created():
     """
 
     return GlobalContext.is_connection_created()
+
+
+def create_connection(site_id=None, client_version=None):
+    """Create global connection.
+
+    Args:
+        site_id (str): Machine site id/name.
+        client_version (str): Desktop app version.
+    """
+
+    GlobalContext.create_connection(site_id, client_version)
 
 
 def close_connection():


### PR DESCRIPTION
## Description
Connection can behave as other user if is using service API key which can be also nested using context manager method 'as_user'. Added more options how connection to server can be created. The global API using environment variables can also expect site id and client version.