### PR TITLE
Fix: Use right method names

### DIFF
--- a/ayon_api/_api.py
+++ b/ayon_api/_api.py
@@ -563,7 +563,7 @@ def get_project_anatomy_preset(*args, **kwargs):
 
 def get_project_roots_by_site(*args, **kwargs):
     con = get_server_api_connection()
-    return con.get_project_roots(*args, **kwargs)
+    return con.get_project_roots_by_site(*args, **kwargs)
 
 
 def get_project_roots_for_site(*args, **kwargs):

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -1609,7 +1609,7 @@ class ServerAPI(object):
 
         if site_id is None:
             return {}
-        roots = self.get_project_roots(project_name)
+        roots = self.get_project_roots_by_site(project_name)
         return roots.get(site_id, {})
 
     def get_addon_settings_schema(


### PR DESCRIPTION
## Description
Fix names of used methods for project root overrides.

## Detailed description
Change usage of `get_project_roots` to `get_project_roots_by_site`.