### PR TITLE
Representation: Fix constant for files fields

### DIFF
--- a/ayon_api/constants.py
+++ b/ayon_api/constants.py
@@ -67,7 +67,7 @@ DEFAULT_REPRESENTATION_FIELDS = {
 }
 
 REPRESENTATION_FILES_FIELDS = {
-    "files.baseName",
+    "files.name",
     "files.hash",
     "files.id",
     "files.path",

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -1182,6 +1182,7 @@ class ServerAPI(object):
             self._graphl_url,
             json=data
         )
+        response.raise_for_status()
         return GraphQlResponse(response)
 
     def get_graphql_schema(self):


### PR DESCRIPTION
## Description
Use `files.name` instead of `files.baseName` as field for representations.