### PR TITLE
`server_api.create_project` remove GraphQL fields

### DIFF
--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -3460,7 +3460,7 @@ class ServerAPI(object):
             Dict[str, Any]: Created project entity.
         """
 
-        if self.get_project(project_name, fields=["name"]):
+        if self.get_project(project_name):
             raise ValueError("Project with name \"{}\" already exists".format(
                 project_name
             ))


### PR DESCRIPTION
We currently pass fields to the GraphQL query when checking if a project exists on Ayon before attempting to create it, this triggers a GraphQL error if the project doesn't exist, since it can't return the specified field.