### PR TITLE
`EntityHub` fix not adding new entities to processed list

### DIFF
--- a/ayon_api/entity_hub.py
+++ b/ayon_api/entity_hub.py
@@ -673,6 +673,7 @@ class EntityHub(object):
             if entity_id in processed_ids:
                 continue
             entity = self._entities_by_id[entity_id]
+            processed_ids.add(entity_id)
             operations_body.append(self._get_create_body(entity))
 
         for entity_id in reversed(removed_entity_ids):


### PR DESCRIPTION
When we are creating new entities we should add their ID to the processed list so that in case the implementation is wrong, it doesn't attempts to create them twice, which will trigger the unique ID error on the server.