### PR TITLE
`EntityHub.delete_entity` fix removing entity from parent children

### DIFF
--- a/ayon_api/entity_hub.py
+++ b/ayon_api/entity_hub.py
@@ -428,7 +428,7 @@ class EntityHub(object):
         if parent_id is None:
             return
 
-        parent = self._entities_by_parent_id.get(parent_id)
+        parent = self._entities_by_id.get(parent_id)
         if parent is not None:
             parent.remove_child(entity.id)
 


### PR DESCRIPTION
When deleting an entity, the `EntityHub` will try to find its parent,
we weren't fetching the actual Ayon entity but the list of children its
parent has, with this change we now find the actual entity of the parent
and perform the `remove_child` against it.