### PR TITLE
GraphQl: Fix events filtering

### DIFF
--- a/ayon_api/graphql_queries.py
+++ b/ayon_api/graphql_queries.py
@@ -314,7 +314,6 @@ def representations_graphql_query(fields):
 def representations_parents_qraphql_query(
     version_fields, subset_fields, folder_fields
 ):
-
     query = GraphQlQuery("RepresentationsParentsQuery")
 
     project_name_var = query.add_variable("projectName", "String!")
@@ -388,7 +387,7 @@ def workfiles_info_graphql_query(fields):
 
 
 def events_graphql_query(fields):
-    query = GraphQlQuery("WorkfilesInfo")
+    query = GraphQlQuery("Events")
     topics_var = query.add_variable("eventTopics", "[String!]")
     projects_var = query.add_variable("projectNames", "[String!]")
     states_var = query.add_variable("eventStates", "[String!]")

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -908,7 +908,7 @@ class ServerAPI(object):
             project_names = set(project_names)
             if not project_names:
                 return
-            filters["projectName"] = list(project_names)
+            filters["projectNames"] = list(project_names)
 
         if states is not None:
             states = set(states)


### PR DESCRIPTION
## Description
Method `get_events` is using filtering key `"projectName"` instead of `"projectNames"` for event filtering.