### PR TITLE
EntityHub: Sync issues with folder and task types

### DIFF
--- a/ayon_api/__init__.py
+++ b/ayon_api/__init__.py
@@ -90,6 +90,7 @@ from ._api import (
     get_projects,
     get_project,
     create_project,
+    update_project,
     delete_project,
 
     get_folder_by_id,
@@ -248,6 +249,7 @@ __all__ = (
     "get_projects",
     "get_project",
     "create_project",
+    "update_project",
     "delete_project",
 
     "get_folder_by_id",

--- a/ayon_api/_api.py
+++ b/ayon_api/_api.py
@@ -801,6 +801,11 @@ def create_project(
     )
 
 
+def update_project(project_name, *args, **kwargs):
+    con = get_server_api_connection()
+    return con.update_project(project_name, *args, **kwargs)
+
+
 def delete_project(project_name):
     con = get_server_api_connection()
     return con.delete_project(project_name)

--- a/ayon_api/entity_hub.py
+++ b/ayon_api/entity_hub.py
@@ -710,13 +710,6 @@ class EntityHub(object):
         for type_name in diff_names:
             new_types.append(orig_types_by_name[type_name])
 
-    def update_project(self, project_name, changes):
-        response = self._connection.patch(
-            "projects/{}".format(project_name),
-            **changes
-        )
-        response.raise_for_status()
-
     def _pre_commit_project(self):
         """Some project changes cannot be committed before hierarchy changes.
 

--- a/ayon_api/entity_hub.py
+++ b/ayon_api/entity_hub.py
@@ -686,6 +686,21 @@ class EntityHub(object):
     def _pre_commit_types_changes(
         self, project_changes, orig_types, changes_key, post_changes
     ):
+        """Compare changes of types on a project.
+
+        Compare old and new types. Change project changes content if some old
+        types were removed. In that case the  final change of types will
+        happen when all other entities have changed.
+
+        Args:
+            project_changes (dict[str, Any]): Project changes.
+            orig_types (list[dict[str, Any]]): Original types.
+            changes_key (Literal[folderTypes, taskTypes]): Key of type changes
+                in project changes.
+            post_changes (dict[str, Any]): An object where post changes will
+                be stored.
+        """
+
         if changes_key not in project_changes:
             return
 

--- a/ayon_api/entity_hub.py
+++ b/ayon_api/entity_hub.py
@@ -683,12 +683,83 @@ class EntityHub(object):
             "entityId": entity.id
         }
 
+    def _pre_commit_types_changes(
+        self, project_changes, orig_types, changes_key, post_changes
+    ):
+        if changes_key not in project_changes:
+            return
+
+        new_types = project_changes[changes_key]
+
+        orig_types_by_name = {
+            type_info["name"]: type_info
+            for type_info in orig_types
+        }
+        new_names = {
+            type_info["name"]
+            for type_info in new_types
+        }
+        diff_names = set(orig_types_by_name) - new_names
+        if not diff_names:
+            return
+
+        # Create copy of folder type changes to post changes
+        #   - post changes will be commited at the end
+        post_changes[changes_key] = copy.deepcopy(new_types)
+
+        for type_name in diff_names:
+            new_types.append(orig_types_by_name[type_name])
+
+    def update_project(self, project_name, changes):
+        response = self._connection.patch(
+            "projects/{}".format(project_name),
+            **changes
+        )
+        response.raise_for_status()
+
+    def _pre_commit_project(self):
+        """Some project changes cannot be committed before hierarchy changes.
+
+        It is not possible to change folder types or task types if there are
+        existing hierarchy items using the removed types. For that purposes
+        is first committed union of all old and new types and post changes
+        are prepared when all existing entities are changed.
+
+        Returns:
+            dict[str, Any]: Changes that will be committed after hierarchy
+                changes.
+        """
+
+        project_changes = self.project_entity.changes
+
+        post_changes = {}
+        if not project_changes:
+            return post_changes
+
+        self._pre_commit_types_changes(
+            project_changes,
+            self.project_entity.get_orig_folder_types(),
+            "folderType",
+            post_changes
+        )
+        self._pre_commit_types_changes(
+            project_changes,
+            self.project_entity.get_orig_task_types(),
+            "taskType",
+            post_changes
+        )
+        self._connection.update_project(self.project_name, **project_changes)
+        return post_changes
+
     def commit_changes(self):
         """Commit any changes that happened on entities.
 
         Todos:
             Use Operations Session instead of known operations body.
         """
+
+        post_project_changes = self._pre_commit_project()
+        self.project_entity.lock()
 
         project_changes = self.project_entity.changes
         if project_changes:
@@ -760,6 +831,9 @@ class EntityHub(object):
         self._connection.send_batch_operations(
             self.project_name, operations_body
         )
+        if post_project_changes:
+            self._connection.update_project(
+                self.project_name, **post_project_changes)
 
         self.lock()
 
@@ -1463,6 +1537,9 @@ class ProjectEntity(BaseEntity):
 
     parent = property(get_parent, set_parent)
 
+    def get_orig_folder_types(self):
+        return copy.deepcopy(self._orig_folder_types)
+
     def get_folder_types(self):
         return copy.deepcopy(self._folder_types)
 
@@ -1473,6 +1550,9 @@ class ProjectEntity(BaseEntity):
                 folder_type["icon"] = self.default_folder_type_icon
             new_folder_types.append(folder_type)
         self._folder_types = new_folder_types
+
+    def get_orig_task_types(self):
+        return copy.deepcopy(self._orig_task_types)
 
     def get_task_types(self):
         return copy.deepcopy(self._task_types)

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -4286,6 +4286,70 @@ class ServerAPI(object):
 
         return self.get_project(project_name)
 
+    def update_project(
+        self,
+        project_name,
+        library=None,
+        folder_types=None,
+        task_types=None,
+        link_types=None,
+        statuses=None,
+        tags=None,
+        config=None,
+        attrib=None,
+        data=None,
+        active=None,
+        project_code=None,
+        **changes
+    ):
+        """Update project entity on server.
+
+        Args:
+            project_name (str): Name of project.
+            library (Optional[bool]): Change library state.
+            folder_types (Optional[list[dict[str, Any]]]): Folder type
+                definitions.
+            task_types (Optional[list[dict[str, Any]]]): Task type
+                definitions.
+            link_types (Optional[list[dict[str, Any]]]): Link type
+                definitions.
+            statuses (Optional[list[dict[str, Any]]]): Status definitions.
+            tags (Optional[list[dict[str, Any]]]): List of tags available to
+                set on entities.
+            config (Optional[dict[dict[str, Any]]]): Project anatomy config
+                with templates and roots.
+            attrib (Optional[dict[str, Any]]): Project attributes to change.
+            data (Optional[dict[str, Any]]): Custom data of a project. This
+                value will 100% override project data.
+            active (Optional[bool]): Change active state of a project.
+            project_code (Optional[str]): Change project code. Not recommended
+                during production.
+            **changes: Other changed keys based on Rest API documentation.
+        """
+
+        changes.update({
+            key: value
+            for key, value in (
+                ("library", library),
+                ("folderTypes", folder_types),
+                ("taskTypes", task_types),
+                ("linkTypes", link_types),
+                ("statuses", statuses),
+                ("tags", tags),
+                ("config", config),
+                ("attrib", attrib),
+                ("data", data),
+                ("active", active),
+                ("code", project_code),
+            )
+            if value is not None
+        })
+        response = self._connection.patch(
+            "projects/{}".format(project_name),
+            **changes
+        )
+        response.raise_for_status()
+
     def delete_project(self, project_name):
         """Delete project from server.
 

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -4344,7 +4344,7 @@ class ServerAPI(object):
             )
             if value is not None
         })
-        response = self._connection.patch(
+        response = self.patch(
             "projects/{}".format(project_name),
             **changes
         )


### PR DESCRIPTION
## Changelog Description
Folder and task type updates can handle renamed type names.

### Deta
Rename of types could cause crash on server side, because they may be in use on existing entities. Entity hub makes sure the union of old and new folder and task types are pushed first, then are done hierarchy changes and at the end is pushed the final state of folder and task types on project.