### PR TITLE
General: Explicit unidecode version for python 2 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["ynput.io <info@ynput.io>"]
 python = ">=2.7,>=3.6.5"
 requests = "^2.28.1"
 six = "^1.15"
-Unidecode = "^1.2"
+Unidecode = "1.2.0" # Python 2 support
 appdirs = "^1.4"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
## Description
Made ayon pi compatible with python 2 by lowering unidecode version.