### PR TITLE
SSL certification: Added option to change certification of ServerAPI

### DIFF
--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -14,7 +14,6 @@ try:
 except ImportError:
     HTTPStatus = None
 
-import certifi
 import requests
 from requests.exceptions import JSONDecodeError as RequestsJSONDecodeError
 

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -315,9 +315,10 @@ class ServerAPI(object):
             default if a method for settings won't get any (by default is
             'production').
         ssl_verify (Union[bool, str, None]): Verify SSL certificate
-            (default is None).
+            Looks for env variable value 'AYON_CA_FILE' by default. If not
+            available then 'True' is used.
         cert (Optional[str]): Path to certificate file. Looks for env
-            variable values 'AYON_CERT_FILE' or 'SSL_CERT_FILE'.
+            variable value 'AYON_CERT_FILE' by default.
     """
 
     def __init__(
@@ -351,6 +352,9 @@ class ServerAPI(object):
             #   with 'certifi'
             if not ssl_verify:
                 ssl_verify = True
+
+        if cert is None:
+            cert = os.environ.get("AYON_CERT_FILE")
 
         self._ssl_verify = ssl_verify
         self._cert = cert

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -344,13 +344,10 @@ class ServerAPI(object):
         self._default_settings_variant = default_settings_variant
 
         if ssl_verify is None:
-            # Custom AYON env variable for CA file
-            ssl_verify = os.environ.get("AYON_CA_FILE")
-            # Use 'True' by default
+            # Custom AYON env variable for CA file or 'True'
             # - that should cover most default behaviors in 'requests'
             #   with 'certifi'
-            if not ssl_verify:
-                ssl_verify = True
+            ssl_verify = os.environ.get("AYON_CA_FILE") or True
 
         if cert is None:
             cert = os.environ.get("AYON_CERT_FILE")


### PR DESCRIPTION
## Description
ServerAPI have option to enable/disable ssl verification and define path to certification file.

### Detailed information
Certification file can be passed to `ServerAPI` init, or use env variable `AYON_CERT_FILE`, or standard `SSL_CERT_FILE` env variable.