### PR TITLE
Desktop: Fix typo in delete installer

### DIFF
--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -1794,7 +1794,7 @@ class ServerAPI(object):
             filename (str): Installer filename.
         """
 
-        response = self.delete("dekstop/installers/{}".format(filename))
+        response = self.delete("desktop/installers/{}".format(filename))
         response.raise_for_status()
 
     def download_installer(


### PR DESCRIPTION
## Desciption
Delete installer (`delete_installer`) is using right endpoint.