### PR TITLE
Status checks: Fix status checks

### DIFF
--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -151,11 +151,13 @@ class RestApiResponse(object):
     def status_code(self):
         return self.status
 
-    def raise_for_status(self):
+    def raise_for_status(self, message=None):
         try:
             self._response.raise_for_status()
         except requests.exceptions.HTTPError as exc:
-            raise HTTPRequestError(str(exc), exc.response)
+            if message is None:
+                message = str(exc)
+            raise HTTPRequestError(message, exc.response)
 
     def __enter__(self, *args, **kwargs):
         return self._response.__enter__(*args, **kwargs)

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -116,6 +116,10 @@ class RestApiResponse(object):
         self._data = data
 
     @property
+    def text(self):
+        return self._response.text
+
+    @property
     def orig_response(self):
         return self._response
 

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -1495,13 +1495,11 @@ class ServerAPI(object):
         """
 
         response = self.delete("attributes/{}".format(attribute_name))
-        if response.status_code != 204:
-            # TODO raise different exception
-            raise ValueError(
-                "Attribute \"{}\" was not created/updated. {}".format(
-                    attribute_name, response.detail
-                )
+        response.raise_for_status(
+            "Attribute \"{}\" was not created/updated. {}".format(
+                attribute_name, response.detail
             )
+        )
 
         self.reset_attributes_schema()
 
@@ -1946,8 +1944,7 @@ class ServerAPI(object):
             checksum=checksum,
             **kwargs
         )
-        if response.status not in (200, 201, 204):
-            raise ServerError("Failed to create/update dependency")
+        response.raise_for_status("Failed to create/update dependency")
         return response.data
 
     def get_dependency_packages(self):
@@ -2082,8 +2079,7 @@ class ServerAPI(object):
 
         route = self._get_dependency_package_route(filename, platform_name)
         response = self.delete(route)
-        if response.status != 200:
-            raise ServerError("Failed to delete dependency file")
+        response.raise_for_status("Failed to delete dependency file")
         return response.data
 
     def download_dependency_package(


### PR DESCRIPTION
## Description
Use `raise_for_status` instead of direct status checks. Method `raise_for_status` has option to raise error with custom message. Added missing `text` attribute to `RestApiResponse`.