### PR TITLE
Create session on ServerAPI initialization

### DIFF
--- a/ayon_api/_api.py
+++ b/ayon_api/_api.py
@@ -25,12 +25,29 @@ class GlobalServerAPI(ServerAPI):
     but that can be filled afterwards with calling 'login' method.
     """
 
-    def __init__(self, site_id=None, client_version=None):
+    def __init__(
+        self,
+        site_id=None,
+        client_version=None,
+        default_settings_variant=None,
+        ssl_verify=None,
+        cert=None,
+    ):
         url = self.get_url()
         token = self.get_token()
 
-        super(GlobalServerAPI, self).__init__(url, token, site_id, client_version)
-
+        super(GlobalServerAPI, self).__init__(
+            url,
+            token,
+            site_id,
+            client_version,
+            default_settings_variant,
+            ssl_verify,
+            cert,
+            # We want to make sure that server and api key validation
+            #   happens all the time in 'GlobalServerAPI'.
+            create_session=False,
+        )
         self.validate_server_availability()
         self.create_session()
 

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -325,6 +325,8 @@ class ServerAPI(object):
             available then 'True' is used.
         cert (Optional[str]): Path to certificate file. Looks for env
             variable value 'AYON_CERT_FILE' by default.
+        create_session (Optional[bool]): Create session for connection if
+            token is available. Default is True.
     """
 
     def __init__(
@@ -336,6 +338,7 @@ class ServerAPI(object):
         default_settings_variant=None,
         ssl_verify=None,
         cert=None,
+        create_session=True,
     ):
         if not base_url:
             raise ValueError("Invalid server URL {}".format(str(base_url)))
@@ -388,6 +391,9 @@ class ServerAPI(object):
 
         self._as_user_stack = _AsUserStack()
         self._thumbnail_cache = ThumbnailCache(True)
+
+        if self._access_token and create_session:
+            self.create_session()
 
     @property
     def log(self):

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -4,7 +4,6 @@ import io
 import json
 import logging
 import collections
-import datetime
 import platform
 import copy
 import uuid

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -685,8 +685,25 @@ class ServerAPI(object):
         self._token_is_valid = None
         self.close_session()
 
-    def create_session(self):
+    def create_session(self, ignore_existing=True, force=False):
+        """Create a connection session.
+
+        Session helps to keep connection with server without
+            need to reconnect on each call.
+
+        Args:
+            ignore_existing (bool): If session already exists,
+                ignore creation.
+            force (bool): If session already exists, close it and
+                create new.
+        """
+
+        if force and self._session is not None:
+            self.close_session()
+
         if self._session is not None:
+            if ignore_existing:
+                return
             raise ValueError("Session is already created.")
 
         self._as_user_stack.clear()

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -1647,7 +1647,7 @@ class ServerAPI(object):
         Args:
             addon_name (str): Name of addon.
             addon_version (str): Version of addon.
-            subpaths (tuple[str]): Any amount of subpaths that are added to
+            *subpaths (str): Any amount of subpaths that are added to
                 addon url.
 
         Returns:

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -870,7 +870,19 @@ class ServerAPI(object):
                     self._access_token)
         return headers
 
-    def login(self, username, password):
+    def login(self, username, password, create_session=True):
+        """Login to server.
+
+        Args:
+            username (str): Username.
+            password (str): Password.
+            create_session (Optional[bool]): Create session after login.
+                Default: True.
+
+        Raises:
+            AuthenticationError: Login failed.
+        """
+
         if self.has_valid_token:
             try:
                 user_info = self.get_user()
@@ -880,7 +892,8 @@ class ServerAPI(object):
             current_username = user_info.get("name")
             if current_username == username:
                 self.close_session()
-                self.create_session()
+                if create_session:
+                    self.create_session()
                 return
 
         self.reset_token()
@@ -904,7 +917,9 @@ class ServerAPI(object):
 
         if not self.has_valid_token:
             raise AuthenticationError("Invalid credentials")
-        self.create_session()
+
+        if create_session:
+            self.create_session()
 
     def logout(self, soft=False):
         if self._access_token:

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -392,7 +392,9 @@ class ServerAPI(object):
         self._as_user_stack = _AsUserStack()
         self._thumbnail_cache = ThumbnailCache(True)
 
+        # Create session
         if self._access_token and create_session:
+            self.validate_server_availability()
             self.create_session()
 
     @property


### PR DESCRIPTION
## Description
Initialization of `ServerAPI` will trigger session creation if token is set, so it is not necessary to call `create_session` after object creation.

## Additional information
In most of cases of `ServerAPI` usage we want to create a session. For cases a session is not created on init and token is passed to init there is a trigger to validate the token before a call to server happens.