### PR TITLE
`events.enroll` allow passing filters

### DIFF
--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -1229,7 +1229,7 @@ class ServerAPI(object):
         sender,
         description=None,
         sequential=None,
-        filter=None,
+        events_filter=None,
     ):
         """Enroll job based on events.
 
@@ -1271,6 +1271,8 @@ class ServerAPI(object):
                 in target event.
             sequential (Optional[bool]): The source topic must be processed
                 in sequence.
+            events_filter (Optional[ayon_server.sqlfilter.Filter]): A dict-like
+                with conditions to filter the source event.
 
         Returns:
             Union[None, dict[str, Any]]: None if there is no event matching
@@ -1286,8 +1288,8 @@ class ServerAPI(object):
             kwargs["sequential"] = sequential
         if description is not None:
             kwargs["description"] = description
-        if filter is not None:
-            kwargs["filter"] = filter
+        if events_filter is not None:
+            kwargs["filter"] = events_filter
         response = self.post("enroll", **kwargs)
         if response.status_code == 204:
             return None

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -1228,7 +1228,8 @@ class ServerAPI(object):
         target_topic,
         sender,
         description=None,
-        sequential=None
+        sequential=None,
+        filter=None,
     ):
         """Enroll job based on events.
 
@@ -1285,6 +1286,8 @@ class ServerAPI(object):
             kwargs["sequential"] = sequential
         if description is not None:
             kwargs["description"] = description
+        if filter is not None:
+            kwargs["filter"] = filter
         response = self.post("enroll", **kwargs)
         if response.status_code == 204:
             return None


### PR DESCRIPTION
The backend allows us to pass filters when enrolling events for a more fine grained query, this commit allows us to specify said filters when enrolling events with this package.