### PR TITLE
Fix login method

### DIFF
--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -900,18 +900,24 @@ class ServerAPI(object):
 
         self.validate_server_availability()
 
-        response = self.post(
-            "auth/login",
-            name=username,
-            password=password
-        )
-        if response.status_code != 200:
-            _detail = response.data.get("detail")
-            details = ""
-            if _detail:
-                details = " {}".format(_detail)
+        self._token_validation_started = True
 
-            raise AuthenticationError("Login failed {}".format(details))
+        try:
+            response = self.post(
+                "auth/login",
+                name=username,
+                password=password
+            )
+            if response.status_code != 200:
+                _detail = response.data.get("detail")
+                details = ""
+                if _detail:
+                    details = " {}".format(_detail)
+
+                raise AuthenticationError("Login failed {}".format(details))
+
+        finally:
+            self._token_validation_started = False
 
         self._access_token = response["token"]
 


### PR DESCRIPTION
## Description
Make sure the login method does not change `_token_is_valid` when calling `post` to login to server.

## Issue description
The login did raise error about invalid credentials even if credentials are valid because the POST method call set that current token is invalid.