### PR TITLE
Entity hub: Project statuses

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,7 @@ If pip complain that `ayon-python-api` is already installed just uninstall exist
     - Move entity hub to first place
     - Skip those which are invalid for the entity and fake it for base or remove it from base
   - Entity hub should use operations session to do changes
-  - Entity hub could also handle 'subset', 'version' and 'representation' entities
-  - Missing 'statuses' on project
+  - Entity hub could also handle 'product', 'version' and 'representation' entities
   - Missing 'status' on folders
   - Missing assignees on tasks
   - Pass docstrings and arguments definitions from `ServerAPI` methods to global functions

--- a/ayon_api/entity_hub.py
+++ b/ayon_api/entity_hub.py
@@ -1515,6 +1515,7 @@ class ProjectStatus:
         color=None,
         index=None,
         project_statuses=None,
+        is_new=None,
     ):
         short_name = short_name or ""
         icon = icon or ""
@@ -1538,7 +1539,9 @@ class ProjectStatus:
 
         self._index = index
         self._project_statuses = project_statuses
-        self._is_new = index is None or project_statuses is None
+        if is_new is None:
+            is_new = index is None or project_statuses is None
+        self._is_new = is_new
 
     def __str__(self):
         short_name = ""
@@ -1941,7 +1944,9 @@ class _ProjectStatuses:
             ProjectStatus: Created project status.
         """
 
-        status = ProjectStatus(name, short_name, state, icon, color)
+        status = ProjectStatus(
+            name, short_name, state, icon, color, is_new=True
+        )
         self.append(status)
         return status
 

--- a/ayon_api/entity_hub.py
+++ b/ayon_api/entity_hub.py
@@ -1900,6 +1900,32 @@ class _ProjectStatuses:
         for status in self._statuses:
             yield status
 
+    def create(
+        self,
+        name,
+        short_name=None,
+        state=None,
+        icon=None,
+        color=None,
+    ):
+        """Create project status.
+
+        Args:
+            name (str): Name of the status. e.g. 'In progress'
+            short_name (Optional[str]): Short name of the status. e.g. 'IP'
+            state (Optional[Literal[not_started, in_progress, done, blocked]]): A
+                state of the status.
+            icon (Optional[str]): Icon of the status. e.g. 'play_arrow'.
+            color (Optional[str]): Color of the status. e.g. '#eeeeee'.
+
+        Returns:
+            ProjectStatus: Created project status.
+        """
+
+        status = ProjectStatus(name, short_name, state, icon, color)
+        self.append(status)
+        return status
+
     def lock(self):
         """Lock statuses.
 

--- a/ayon_api/entity_hub.py
+++ b/ayon_api/entity_hub.py
@@ -1882,6 +1882,18 @@ class ProjectStatus:
 
 
 class _ProjectStatuses:
+    """Wrapper for project statuses.
+
+    Supports basic methods to add, change or remove statuses from a project.
+
+    To add new statuses use 'create' or 'add_status' methods. To change
+        statuses receive them by one of the getter methods and change their
+        values.
+
+    Todos:
+        Validate if statuses are duplicated.
+    """
+
     def __init__(self, statuses):
         self._statuses = [
             ProjectStatus.from_data(status, idx, self)

--- a/ayon_api/entity_hub.py
+++ b/ayon_api/entity_hub.py
@@ -1567,7 +1567,7 @@ class ProjectStatus:
         raise KeyError(key)
 
     def lock(self):
-        """Lock statuse.
+        """Lock status.
 
         Changes were commited and current values are now the original values.
         """
@@ -1804,6 +1804,15 @@ class ProjectStatus:
     icon = property(get_icon, set_icon)
 
     def _validate_other_p_statuses(self, other):
+        """Validate if other status can be used for move.
+
+        To be able to work with other status, and position them in relation,
+        they must belong to same existing object of '_ProjectStatuses'.
+
+        Args:
+            other (ProjectStatus): Other status to validate.
+        """
+
         o_project_statuses = other.project_statuses
         m_project_statuses = self.project_statuses
         if o_project_statuses is None and m_project_statuses is None:

--- a/ayon_api/entity_hub.py
+++ b/ayon_api/entity_hub.py
@@ -1513,7 +1513,14 @@ class ProjectEntity(BaseEntity):
     default_task_type_icon = "task_alt"
 
     def __init__(
-        self, project_code, library, folder_types, task_types, *args, **kwargs
+        self,
+        project_code,
+        library,
+        folder_types,
+        task_types,
+        statuses,
+        *args,
+        **kwargs
     ):
         super(ProjectEntity, self).__init__(*args, **kwargs)
 
@@ -1521,11 +1528,20 @@ class ProjectEntity(BaseEntity):
         self._library_project = library
         self._folder_types = folder_types
         self._task_types = task_types
+        self._statuses = statuses
 
         self._orig_project_code = project_code
         self._orig_library_project = library
         self._orig_folder_types = copy.deepcopy(folder_types)
         self._orig_task_types = copy.deepcopy(task_types)
+        self._orig_statuses = copy.deepcopy(statuses)
+        {
+            "name": "Not ready",
+            "icon": "fiber_new",
+            "color": "#434a56",
+            "state": "not_started",
+            "shortName": "NRD"
+        }
 
     def _prepare_entity_id(self, entity_id):
         if entity_id != self.project_name:

--- a/ayon_api/entity_hub.py
+++ b/ayon_api/entity_hub.py
@@ -775,8 +775,7 @@ class EntityHub(object):
                 "projects/{}".format(self.project_name),
                 **project_changes
             )
-            if response.status_code != 204:
-                raise ValueError("Failed to update project")
+            response.raise_for_status()
 
         self.project_entity.lock()
 

--- a/ayon_api/entity_hub.py
+++ b/ayon_api/entity_hub.py
@@ -1872,7 +1872,7 @@ class ProjectStatus:
 
         return cls(
             data["name"],
-            data.get("shortName"),
+            data.get("shortName", data.get("short_name")),
             data.get("state"),
             data.get("icon"),
             data.get("color"),

--- a/ayon_api/entity_hub.py
+++ b/ayon_api/entity_hub.py
@@ -1902,6 +1902,9 @@ class _ProjectStatuses:
         self._orig_status_length = len(self._statuses)
         self._set_called = False
 
+    def __len__(self):
+        return len(self._statuses)
+
     def __iter__(self):
         """Iterate over statuses.
 

--- a/ayon_api/entity_hub.py
+++ b/ayon_api/entity_hub.py
@@ -1,10 +1,11 @@
+import re
 import copy
 import collections
 from abc import ABCMeta, abstractmethod
 
 import six
 from ._api import get_server_api_connection
-from .utils import create_entity_id, convert_entity_id
+from .utils import create_entity_id, convert_entity_id, slugify_string
 
 UNKNOWN_VALUE = object()
 PROJECT_PARENT_ID = object()
@@ -545,6 +546,7 @@ class EntityHub(object):
             library=project["library"],
             folder_types=project["folderTypes"],
             task_types=project["taskTypes"],
+            statuses=project["statuses"],
             name=project["name"],
             attribs=project["ownAttrib"],
             data=project["data"],
@@ -1484,6 +1486,663 @@ class BaseEntity(object):
         self._children_ids = set(children_ids)
 
 
+class ProjectStatus:
+    """Project status class.
+
+    Args:
+        name (str): Name of the status. e.g. 'In progress'
+        short_name (Optional[str]): Short name of the status. e.g. 'IP'
+        state (Optional[Literal[not_started, in_progress, done, blocked]]): A
+            state of the status.
+        icon (Optional[str]): Icon of the status. e.g. 'play_arrow'.
+        color (Optional[str]): Color of the status. e.g. '#eeeeee'.
+        index (Optional[int]): Index of the status.
+        project_statuses (Optional[_ProjectStatuses]): Project statuses
+            wrapper.
+    """
+
+    valid_states = ("not_started", "in_progress", "done", "blocked")
+    color_regex = re.compile(r"#([a-f0-9]{6})$")
+    default_state = "in_progress"
+    default_color = "#eeeeee"
+
+    def __init__(
+        self,
+        name,
+        short_name=None,
+        state=None,
+        icon=None,
+        color=None,
+        index=None,
+        project_statuses=None,
+    ):
+        short_name = short_name or ""
+        icon = icon or ""
+        state = state or self.default_state
+        color = color or self.default_color
+        self._name = name
+        self._short_name = short_name
+        self._icon = icon
+        self._slugified_name = None
+        self._state = None
+        self._color = None
+        self.set_state(state)
+        self.set_color(color)
+
+        self._original_name = name
+        self._original_short_name = short_name
+        self._original_icon = icon
+        self._original_state = state
+        self._original_color = color
+        self._original_index = index
+
+        self._index = index
+        self._project_statuses = project_statuses
+        self._is_new = index is None or project_statuses is None
+
+    def __str__(self):
+        short_name = ""
+        if self.short_name:
+            short_name = "({})".format(self.short_name)
+        return "<{} {}{}>".format(
+            self.__class__.__name__, self.name, short_name
+        )
+
+    def __repr__(self):
+        return str(self)
+
+    def __getitem__(self, key):
+        if key in {
+            "name", "short_name", "icon", "state", "color", "slugified_name"
+        }:
+            return getattr(self, key)
+        raise KeyError(key)
+
+    def __setitem__(self, key, value):
+        if key in {"name", "short_name", "icon", "state", "color"}:
+            return setattr(self, key, value)
+        raise KeyError(key)
+
+    def lock(self):
+        """Lock statuse.
+
+        Changes were commited and current values are now the original values.
+        """
+
+        self._is_new = False
+        self._original_name = self.name
+        self._original_short_name = self.short_name
+        self._original_icon = self.icon
+        self._original_state = self.state
+        self._original_color = self.color
+        self._original_index = self.index
+
+    @staticmethod
+    def slugify_name(name):
+        """Slugify status name for name comparison.
+
+        Args:
+            name (str): Name of the status.
+
+        Returns:
+            str: Slugified name.
+        """
+
+        return slugify_string(name.lower())
+
+    def get_project_statuses(self):
+        """Internal logic method.
+
+        Returns:
+            _ProjectStatuses: Project statuses object.
+        """
+
+        return self._project_statuses
+
+    def set_project_statuses(self, project_statuses):
+        """Internal logic method to change parent object.
+
+        Args:
+            project_statuses (_ProjectStatuses): Project statuses object.
+        """
+
+        self._project_statuses = project_statuses
+
+    def unset_project_statuses(self, project_statuses):
+        """Internal logic method to unset parent object.
+
+        Args:
+            project_statuses (_ProjectStatuses): Project statuses object.
+        """
+
+        if self._project_statuses is project_statuses:
+            self._project_statuses = None
+            self._index = None
+
+    @property
+    def changed(self):
+        """Status has changed.
+
+        Returns:
+            bool: Status has changed.
+        """
+
+        return (
+            self._is_new
+            or self._original_name != self._name
+            or self._original_short_name != self._short_name
+            or self._original_index != self._index
+            or self._original_state != self._state
+            or self._original_icon != self._icon
+            or self._original_color != self._color
+        )
+
+    def delete(self):
+        """Remove status from project statuses object."""
+
+        if self._project_statuses is not None:
+            self._project_statuses.remove(self)
+
+    def get_index(self):
+        """Get index of status.
+
+        Returns:
+            Union[int, None]: Index of status or None if status is not under
+                project.
+        """
+
+        return self._index
+
+    def set_index(self, index, **kwargs):
+        """Change status index.
+
+        Returns:
+            Union[int, None]: Index of status or None if status is not under
+                project.
+        """
+
+        if kwargs.get("from_parent"):
+            self._index = index
+        else:
+            self._project_statuses.set_status_index(self, index)
+
+    def get_name(self):
+        """Status name.
+
+        Returns:
+            str: Status name.
+        """
+
+        return self._name
+
+    def set_name(self, name):
+        """Change status name.
+
+        Args:
+            name (str): New status name.
+        """
+
+        if not isinstance(name, six.string_types):
+            raise TypeError("Name must be a string.")
+        if name == self._name:
+            return
+        self._name = name
+        self._slugified_name = None
+
+    def get_short_name(self):
+        """Status short name 3 letters tops.
+
+        Returns:
+            str: Status short name.
+        """
+
+        return self._short_name
+
+    def set_short_name(self, short_name):
+        """Change status short name.
+
+        Args:
+            short_name (str): New status short name. 3 letters tops.
+        """
+
+        if not isinstance(short_name, six.string_types):
+            raise TypeError("Short name must be a string.")
+        self._short_name = short_name
+
+    def get_icon(self):
+        """Name of icon to use for status.
+
+        Returns:
+            str: Name of the icon.
+        """
+
+        return self._icon
+
+    def set_icon(self, icon):
+        """Change status icon name.
+
+        Args:
+            icon (str): Name of the icon.
+        """
+
+        if icon is None:
+            icon = ""
+        if not isinstance(icon, six.string_types):
+            raise TypeError("Icon name must be a string.")
+        self._icon = icon
+
+    @property
+    def slugified_name(self):
+        """Slugified and lowere status name.
+
+        Can be used for comparison of existing statuses. e.g. 'In Progress'
+            vs. 'in-progress'.
+
+        Returns:
+            str: Slugified and lower status name.
+        """
+
+        if self._slugified_name is None:
+            self._slugified_name = self.slugify_name(self.name)
+        return self._slugified_name
+
+    def get_state(self):
+        """Get state of project status.
+
+        Return:
+            Literal[not_started, in_progress, done, blocked]: General
+                state of status.
+        """
+
+        return self._state
+
+    def set_state(self, state):
+        """Set color of project status.
+
+        Args:
+            state (Literal[not_started, in_progress, done, blocked]): General
+                state of status.
+        """
+
+        if state not in self.valid_states:
+            raise ValueError("Invalid state '{}'".format(str(state)))
+        self._state = state
+
+    def get_color(self):
+        """Get color of project status.
+
+        Returns:
+            str: Status color.
+        """
+
+        return self._color
+
+    def set_color(self, color):
+        """Set color of project status.
+
+        Args:
+            color (str): Color in hex format. Example: '#ff0000'.
+        """
+
+        if not isinstance(color, six.string_types):
+            raise TypeError(
+                "Color must be string got '{}'".format(type(color)))
+        color = color.lower()
+        if self.color_regex.fullmatch(color) is None:
+            raise ValueError("Invalid color value '{}'".format(color))
+        self._color = color
+
+    name = property(get_name, set_name)
+    short_name = property(get_short_name, set_short_name)
+    project_statuses = property(get_project_statuses, set_project_statuses)
+    index = property(get_index, set_index)
+    state = property(get_state, set_state)
+    color = property(get_color, set_color)
+    icon = property(get_icon, set_icon)
+
+    def _validate_other_p_statuses(self, other):
+        o_project_statuses = other.project_statuses
+        m_project_statuses = self.project_statuses
+        if o_project_statuses is None and m_project_statuses is None:
+            raise ValueError("Both statuses are not assigned to a project.")
+
+        missing_status = None
+        if o_project_statuses is None:
+            missing_status = other
+        elif m_project_statuses is None:
+            missing_status = self
+        if missing_status is not None:
+            raise ValueError(
+                "Status '{}' is not assigned to a project.".format(
+                    missing_status.name))
+        if m_project_statuses is not o_project_statuses:
+            raise ValueError(
+                "Statuse are assigned to different projects."
+                " Cannot execute move."
+            )
+
+    def move_before(self, other):
+        """Move status before other status.
+
+        Args:
+            other (ProjectStatus): Status to move before.
+        """
+
+        self._validate_other_p_statuses(other)
+        self._project_statuses.set_status_index(self, other.index)
+
+    def move_after(self, other):
+        """Move status after other status.
+
+        Args:
+            other (ProjectStatus): Status to move after.
+        """
+
+        self._validate_other_p_statuses(other)
+        self._project_statuses.set_status_index(self, other.index + 1)
+
+    def to_data(self):
+        """Convert status to data.
+
+        Returns:
+            dict[str, str]: Status data.
+        """
+
+        output = {
+            "name": self.name,
+            "shortName": self.short_name,
+            "state": self.state,
+            "icon": self.icon,
+            "color": self.color,
+        }
+        if self._original_name and self.name != self._original_name:
+            output["original_name"] = self._original_name
+        return output
+
+    @classmethod
+    def from_data(cls, data, index=None, project_statuses=None):
+        """Create project status from data.
+
+        Args:
+            data (dict[str, str]): Status data.
+            index (Optional[int]): Status index.
+            project_statuses (Optional[ProjectStatuses]): Project statuses
+                object which wraps the status for a project.
+        """
+
+        return cls(
+            data["name"],
+            data.get("shortName"),
+            data.get("state"),
+            data.get("icon"),
+            data.get("color"),
+            index=index,
+            project_statuses=project_statuses
+        )
+
+
+class _ProjectStatuses:
+    def __init__(self, statuses):
+        self._statuses = [
+            ProjectStatus.from_data(status, idx, self)
+            for idx, status in enumerate(statuses)
+        ]
+        self._orig_status_length = len(self._statuses)
+        self._set_called = False
+
+    def __iter__(self):
+        """Iterate over statuses.
+
+        Yields:
+            ProjectStatus: Project status.
+        """
+
+        for status in self._statuses:
+            yield status
+
+    def lock(self):
+        """Lock statuses.
+
+        Changes were commited and current values are now the original values.
+        """
+
+        self._orig_status_length = len(self._statuses)
+        self._set_called = False
+        for status in self._statuses:
+            status.lock()
+
+    def to_data(self):
+        """Convert to project statuses data."""
+
+        return [
+            status.to_data()
+            for status in self._statuses
+        ]
+
+    def set(self, statuses):
+        """Explicitly override statuses.
+
+        This method does not handle if statuses changed or not.
+
+        Args:
+            statuses (list[dict[str, str]]): List of statuses data.
+        """
+
+        self._set_called = True
+        self._statuses = [
+            ProjectStatus.from_data(status, idx, self)
+            for idx, status in enumerate(statuses)
+        ]
+
+    @property
+    def changed(self):
+        """Statuses have changed.
+
+        Returns:
+            bool: True if statuses changed, False otherwise.
+        """
+
+        if self._set_called:
+            return True
+
+        # Check if status length changed
+        #   - when all statuses are removed it is a changed
+        if self._orig_status_length != len(self._statuses):
+            return True
+        # Go through all statuses and check if any of them changed
+        for status in self._statuses:
+            if status.changed:
+                return True
+        return False
+
+    def get(self, name, default=None):
+        """Get status by name.
+
+        Args:
+            name (str): Status name.
+            default (Any): Default value of status is not found.
+
+        Returns:
+            Union[ProjectStatus, Any]: Status or default value.
+        """
+
+        return next(
+            (
+                status
+                for status in self._statuses
+                if status.name == name
+            ),
+            default
+        )
+
+    get_status_by_name = get
+
+    def index(self, status, **kwargs):
+        """Get status index.
+
+        Args:
+            status (ProjectStatus): Status to get index of.
+            default (Optional[Any]): Default value if status is not found.
+
+        Returns:
+            Union[int, Any]: Status index.
+
+        Raises:
+            ValueError: If status is not found and default value is not
+                defined.
+        """
+
+        output = next(
+            (
+                idx
+                for idx, st in enumerate(self._statuses)
+                if st is status
+            ),
+            None
+        )
+        if output is not None:
+            return output
+
+        if "default" in kwargs:
+            return kwargs["default"]
+        raise ValueError("Status '{}' not found".format(status.name))
+
+    def get_status_by_slugified_name(self, name):
+        """Get status by slugified name.
+
+        Args:
+            name (str): Status name. Is slugified before search.
+
+        Returns:
+            Union[ProjectStatus, None]: Status or None if not found.
+        """
+
+        slugified_name = ProjectStatus.slugify_name(name)
+        return next(
+            (
+                status
+                for status in self._statuses
+                if status.slugified_name == slugified_name
+            ),
+            None
+        )
+
+    def remove_by_name(self, name, ignore_missing=False):
+        """Remove status by name.
+
+        Args:
+            name (str): Status name.
+            ignore_missing (Optional[bool]): If True, no error is raised if
+                status is not found.
+
+        Returns:
+            ProjectStatus: Removed status.
+        """
+
+        matching_status = self.get(name)
+        if matching_status is None:
+            if ignore_missing:
+                return
+            raise ValueError(
+                "Status '{}' not found in project".format(name))
+        return self.remove(matching_status)
+
+    def remove(self, status, ignore_missing=False):
+        """Remove status.
+
+        Args:
+            status (ProjectStatus): Status to remove.
+            ignore_missing (Optional[bool]): If True, no error is raised if
+                status is not found.
+
+        Returns:
+            Union[ProjectStatus, None]: Removed status.
+        """
+
+        index = self.index(status, default=None)
+        if index is None:
+            if ignore_missing:
+                return None
+            raise ValueError("Status '{}' not in project".format(status))
+
+        return self.pop(index)
+
+    def pop(self, index):
+        """Remove status by index.
+
+        Args:
+            index (int): Status index.
+
+        Returns:
+            ProjectStatus: Removed status.
+        """
+
+        status = self._statuses.pop(index)
+        status.unset_project_statuses(self)
+        for st in self._statuses[index:]:
+            st.set_index(st.index - 1, from_parent=True)
+        return status
+
+    def insert(self, index, status):
+        """Insert status at index.
+
+        Args:
+            index (int): Status index.
+            status (Union[ProjectStatus, dict[str, str]]): Status to insert.
+                Can be either status object or status data.
+
+        Returns:
+            ProjectStatus: Inserted status.
+        """
+
+        if not isinstance(status, ProjectStatus):
+            status = ProjectStatus.from_data(status)
+
+        start_index = index
+        end_index = len(self._statuses) + 1
+        matching_index = self.index(status, default=None)
+        if matching_index is not None:
+            if matching_index == index:
+                status.set_index(index, from_parent=True)
+                return
+
+            self._statuses.pop(matching_index)
+            if matching_index < index:
+                start_index = matching_index
+                end_index = index + 1
+            else:
+                end_index -= 1
+
+        status.set_project_statuses(self)
+        self._statuses.insert(index, status)
+        for idx, st in enumerate(self._statuses[start_index:end_index]):
+            st.set_index(start_index + idx, from_parent=True)
+        return status
+
+    def append(self, status):
+        """Add new status to the end of the list.
+
+        Args:
+            status (Union[ProjectStatus, dict[str, str]]): Status to insert.
+                Can be either status object or status data.
+
+        Returns:
+            ProjectStatus: Inserted status.
+        """
+
+        return self.insert(len(self._statuses), status)
+
+    def set_status_index(self, status, index):
+        """Set status index.
+
+        Args:
+            status (ProjectStatus): Status to set index.
+            index (int): New status index.
+        """
+
+        return self.insert(index, status)
+
+
 class ProjectEntity(BaseEntity):
     """Entity representing project on AYON server.
 
@@ -1528,20 +2187,13 @@ class ProjectEntity(BaseEntity):
         self._library_project = library
         self._folder_types = folder_types
         self._task_types = task_types
-        self._statuses = statuses
+        self._statuses_obj = _ProjectStatuses(statuses)
 
         self._orig_project_code = project_code
         self._orig_library_project = library
         self._orig_folder_types = copy.deepcopy(folder_types)
         self._orig_task_types = copy.deepcopy(task_types)
         self._orig_statuses = copy.deepcopy(statuses)
-        {
-            "name": "Not ready",
-            "icon": "fiber_new",
-            "color": "#434a56",
-            "state": "not_started",
-            "shortName": "NRD"
-        }
 
     def _prepare_entity_id(self, entity_id):
         if entity_id != self.project_name:
@@ -1588,13 +2240,24 @@ class ProjectEntity(BaseEntity):
             new_task_types.append(task_type)
         self._task_types = new_task_types
 
+    def get_orig_statuses(self):
+        return copy.deepcopy(self._orig_statuses)
+
+    def get_statuses(self):
+        return self._statuses_obj
+
+    def set_statuses(self, statuses):
+        self._statuses_obj.set(statuses)
+
     folder_types = property(get_folder_types, set_folder_types)
     task_types = property(get_task_types, set_task_types)
+    statuses = property(get_statuses, set_statuses)
 
     def lock(self):
         super(ProjectEntity, self).lock()
         self._orig_folder_types = copy.deepcopy(self._folder_types)
         self._orig_task_types = copy.deepcopy(self._task_types)
+        self._statuses_obj.lock()
 
     @property
     def changes(self):
@@ -1604,6 +2267,9 @@ class ProjectEntity(BaseEntity):
 
         if self._orig_task_types != self._task_types:
             changes["taskTypes"] = self.get_task_types()
+
+        if self._statuses_obj.changed:
+            changes["statuses"] = self._statuses_obj.to_data()
 
         return changes
 

--- a/ayon_api/entity_hub.py
+++ b/ayon_api/entity_hub.py
@@ -1855,7 +1855,11 @@ class ProjectStatus:
             "icon": self.icon,
             "color": self.color,
         }
-        if self._original_name and self.name != self._original_name:
+        if (
+            not self._is_new
+            and self._original_name
+            and self.name != self._original_name
+        ):
             output["original_name"] = self._original_name
         return output
 


### PR DESCRIPTION
## Description
Implemented changes of project statuses for entity hub.

## Detailed description
Project entity has `statuses` which is object that helps to maintain statuses. It is possible to access existing statuses, modify or remove them, or create new statuses.

```python
from ayon_api.entity_hub import EntityHub

project_name = "<Your project>"
entity_hub = EntityHub(project_name)
project = entity_hub.project_entity

# --- Create new status ---
new_status = project.statuses.create("testStatus")
entity_hub.commit_changes()

# --- Change order of status ---
new_status.set_index(0)
entity_hub.commit_changes()

# --- Completelly override all existing statuses ---
# - this will probably crash because other statuses will be used (it is not possible to remove statuses that are used)
project.statuses.set([
    {
        "name": "TheOnlyOne",
        "shortName": "NEO",
        "color": "#008f11",
        "state": "done",
        "icon": "eyeglasses"
    }
])
entity_hub.commit_changes()
```