### PR TITLE
Use correct appdirs

### DIFF
--- a/ayon_api/thumbnails.py
+++ b/ayon_api/thumbnails.py
@@ -50,7 +50,7 @@ class ThumbnailCache:
         """
 
         if self._thumbnails_dir is None:
-            directory = appdirs.user_data_dir("ayon", "ynput")
+            directory = appdirs.user_data_dir("AYON", "Ynput")
             self._thumbnails_dir = os.path.join(directory, "thumbnails")
         return self._thumbnails_dir
 


### PR DESCRIPTION
## Description
Thumbnail cache is using correct appdirs where to store thumbnails. Changed to `AYON` and `Ynput`.

## Todos
Remove caching from ayon python api completelly.