### PR TITLE
Server 0.4.x support

### DIFF
--- a/ayon_api/constants.py
+++ b/ayon_api/constants.py
@@ -6,13 +6,13 @@ SERVER_TOKEN_ENV_KEY = SERVER_API_ENV_KEY
 
 # --- User ---
 DEFAULT_USER_FIELDS = {
-    "roles",
+    "accessGroups",
+    "defaultAccessGroups",
     "name",
     "isService",
     "isManager",
     "isGuest",
     "isAdmin",
-    "defaultRoles",
     "createdAt",
     "active",
     "hasPassword",

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -890,9 +890,17 @@ class ServerAPI(object):
         for attr, filter_value in filters.items():
             query.set_variable_value(attr, filter_value)
 
+        # Backwards compatibility for server 0.3.x
+        #   - will be removed in future releases
+        major, minor, _, _, _ = self.server_version_tuple
+        access_groups_field = "accessGroups"
+        if major == 0 and minor <= 3:
+            access_groups_field = "roles"
+
         for parsed_data in query.continuous_query(self):
             for user in parsed_data["users"]:
-                user["roles"] = json.loads(user["roles"])
+                user[access_groups_field] = json.loads(
+                    user[access_groups_field])
                 yield user
 
     def get_user(self, username=None):
@@ -1747,7 +1755,15 @@ class ServerAPI(object):
             entity_type_defaults = DEFAULT_WORKFILE_INFO_FIELDS
 
         elif entity_type == "user":
-            entity_type_defaults = DEFAULT_USER_FIELDS
+            entity_type_defaults = set(DEFAULT_USER_FIELDS)
+            # Backwards compatibility for server 0.3.x
+            #   - will be removed in future releases
+            major, minor, _, _, _ = self.server_version_tuple
+            if major == 0 and minor <= 3:
+                entity_type_defaults.discard("accessGroups")
+                entity_type_defaults.discard("defaultAccessGroups")
+                entity_type_defaults.add("roles")
+                entity_type_defaults.add("defaultRoles")
 
         else:
             raise ValueError("Unknown entity type \"{}\"".format(entity_type))

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -2140,7 +2140,12 @@ class ServerAPI(object):
                 server.
         """
 
-        result = self.get("desktop/dependency_packages")
+        endpoint = "desktop/dependencyPackages"
+        major, minor, _, _, _ = self.server_version_tuple
+        if major == 0 and minor <= 3:
+            endpoint = "desktop/dependency_packages"
+
+        result = self.get(endpoint)
         result.raise_for_status()
         return result.data
 


### PR DESCRIPTION
## Description
Added support for 0.4.x server.

## Additional information
The only differences are that user `roles` were renamed to `accessGroups` and `dependency_packages` endpoint is now in camel case (`dependencyPackages`).