### PR TITLE
Dependency packages endpoint

### DIFF
--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -2284,11 +2284,7 @@ class ServerAPI(object):
                 server.
         """
 
-        endpoint = "desktop/dependencyPackages"
-        major, minor, _, _, _ = self.server_version_tuple
-        if major == 0 and minor <= 3:
-            endpoint = "desktop/dependency_packages"
-
+        endpoint = self._get_dependency_package_route()
         result = self.get(endpoint)
         result.raise_for_status()
         return result.data

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -931,8 +931,8 @@ class ServerAPI(object):
                 int(re_match.group("major")),
                 int(re_match.group("minor")),
                 int(re_match.group("patch")),
-                re_match.group("prerelease"),
-                re_match.group("buildmetadata")
+                re_match.group("prerelease") or "",
+                re_match.group("buildmetadata") or "",
             )
         return self._server_version_tuple
 


### PR DESCRIPTION
## Description
Use `dependencyPackages` endpoint instead of `dependency_packages`. Add warning for deprecated `dependencies` endpoint.

### Additional information
Ednpoint `dependency_packages` is deprecated and will be removed from server soon.