### PR TITLE
Events: progress and retries could be updated on a event

### DIFF
--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -1335,14 +1335,16 @@ class ServerAPI(object):
                 yield event
 
     def update_event(
-        self,
-        event_id,
-        sender=None,
-        project_name=None,
-        status=None,
-        description=None,
-        summary=None,
-        payload=None
+            self,
+            event_id,
+            sender=None,
+            project_name=None,
+            status=None,
+            description=None,
+            summary=None,
+            payload=None,
+            progress=None,
+            retries=None
     ):
         kwargs = {
             key: value
@@ -1353,6 +1355,8 @@ class ServerAPI(object):
                 ("description", description),
                 ("summary", summary),
                 ("payload", payload),
+                ("progress", progress),
+                ("retries", retries),
             )
             if value is not None
         }

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -1489,8 +1489,10 @@ class ServerAPI(object):
                 in target event.
             sequential (Optional[bool]): The source topic must be processed
                 in sequence.
-            events_filter (Optional[ayon_server.sqlfilter.Filter]): A
-                dict-like with conditions to filter the source event.
+            events_filter (Optional[dict[str, Any]]): Filtering conditions
+                to filter the source event. For more technical specifications
+                look to server backed 'ayon_server.sqlfilter.Filter'.
+                TODO: Add example of filters.
             max_retries (Optional[int]): How many times can be event retried.
                 Default value is based on server (3 at the time of this PR).
 

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -1360,6 +1360,21 @@ class ServerAPI(object):
             )
             if value is not None
         }
+        # 'progress' and 'retries' are available since 0.5.x server version
+        major, minor, _, _, _ = self.server_version_tuple
+        if (major, minor) < (0, 5):
+            args = []
+            if progress is not None:
+                args.append("progress")
+            if retries is not None:
+                args.append("retries")
+            fields = ", ".join("'{}'".format(f) for f in args)
+            ending = "s" if len(args) > 1 else ""
+            raise ValueError((
+                "Your server version '{}' does not support update"
+                " of {} field{} on event."
+            ).format(self.get_server_version(), fields, ending))
+
         response = self.patch(
             "events/{}".format(event_id),
             **kwargs

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -1371,8 +1371,8 @@ class ServerAPI(object):
             fields = ", ".join("'{}'".format(f) for f in args)
             ending = "s" if len(args) > 1 else ""
             raise ValueError((
-                "Your server version '{}' does not support update"
-                " of {} field{} on event."
+                 "Your server version '{}' does not support update"
+                 " of {} field{} on event. Use version at least 0.5"
             ).format(self.get_server_version(), fields, ending))
 
         response = self.patch(

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -1335,16 +1335,16 @@ class ServerAPI(object):
                 yield event
 
     def update_event(
-            self,
-            event_id,
-            sender=None,
-            project_name=None,
-            status=None,
-            description=None,
-            summary=None,
-            payload=None,
-            progress=None,
-            retries=None
+        self,
+        event_id,
+        sender=None,
+        project_name=None,
+        status=None,
+        description=None,
+        summary=None,
+        payload=None,
+        progress=None,
+        retries=None
     ):
         kwargs = {
             key: value

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -1372,7 +1372,8 @@ class ServerAPI(object):
             ending = "s" if len(args) > 1 else ""
             raise ValueError((
                  "Your server version '{}' does not support update"
-                 " of {} field{} on event. Use version at least 0.5"
+                 " of {} field{} on event. The fields are supported since"
+                 " server version '0.5'."
             ).format(self.get_server_version(), fields, ending))
 
         response = self.patch(

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -1447,6 +1447,7 @@ class ServerAPI(object):
         description=None,
         sequential=None,
         events_filter=None,
+        max_retries=None,
     ):
         """Enroll job based on events.
 
@@ -1488,8 +1489,10 @@ class ServerAPI(object):
                 in target event.
             sequential (Optional[bool]): The source topic must be processed
                 in sequence.
-            events_filter (Optional[ayon_server.sqlfilter.Filter]): A dict-like
-                with conditions to filter the source event.
+            events_filter (Optional[ayon_server.sqlfilter.Filter]): A
+                dict-like with conditions to filter the source event.
+            max_retries (Optional[int]): How many times can be event retried.
+                Default value is based on server (3 at the time of this PR).
 
         Returns:
             Union[None, dict[str, Any]]: None if there is no event matching
@@ -1500,6 +1503,7 @@ class ServerAPI(object):
             "sourceTopic": source_topic,
             "targetTopic": target_topic,
             "sender": sender,
+            "maxRetries": max_retries,
         }
         if sequential is not None:
             kwargs["sequential"] = sequential


### PR DESCRIPTION
## Description
Added support of `progress` and `retries` on event endpoints. Those were added in server `0.5.x`.