### PR TITLE
Max retries: Continue in retries on ConnectionError

### DIFF
--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -1144,20 +1144,19 @@ class ServerAPI(object):
                     None,
                     {"detail": "Unable to connect the server. Connection refused"}
                 )
+
             except requests.exceptions.Timeout:
                 # Connection timed out
                 new_response = RestApiResponse(
                     None,
                     {"detail": "Connection timed out."}
                 )
+
             except requests.exceptions.ConnectionError:
-                # Other connection error (ssl, etc) - does not make sense to
-                #   try call server again
                 new_response = RestApiResponse(
                     None,
                     {"detail": "Unable to connect the server. Connection error"}
                 )
-                break
 
             time.sleep(0.1)
 


### PR DESCRIPTION
## Description
Do not break on connection error and continue in retries. Also log warning with error on last try, to know what exactly happened.

### Additional information
Connection error can happen when a connection is in closing state on server and client send new request.