### PR TITLE
Prepare entity hub for folder paths starting with slash

### DIFF
--- a/ayon_api/entity_hub.py
+++ b/ayon_api/entity_hub.py
@@ -2437,10 +2437,13 @@ class FolderEntity(BaseEntity):
 
         if self._path is None:
             parent = self.parent
-            path = self.name
             if parent.entity_type == "folder":
                 parent_path = parent.path
-                path = "/".join([parent_path, path])
+                path = "/".join([parent_path, self.name])
+            elif self._entity_hub.path_start_with_slash:
+                path = "/{}".format(self.name)
+            else:
+                path = self.name
             self._path = path
         return self._path
 

--- a/ayon_api/entity_hub.py
+++ b/ayon_api/entity_hub.py
@@ -40,7 +40,13 @@ class EntityHub(object):
     ):
         if not connection:
             connection = get_server_api_connection()
+        major, minor, _, _, _ = connection.server_version_tuple
+        path_start_with_slash = True
+        if (major, minor) < (0, 6):
+            path_start_with_slash = False
+
         self._connection = connection
+        self._path_start_with_slash = path_start_with_slash
 
         self._project_name = project_name
         self._entities_by_id = {}
@@ -64,6 +70,18 @@ class EntityHub(object):
         """
 
         return self._allow_data_changes
+
+    @property
+    def path_start_with_slash(self):
+        """Folder path should start with slash.
+
+        This changed in 0.6.x server version.
+
+        Returns:
+            bool: Path starts with slash.
+        """
+
+        return self._path_start_with_slash
 
     @property
     def project_name(self):


### PR DESCRIPTION
## Description
With AYON server version 0.6.x will folder paths start with slash. Entity hub was changed accordingly.