### PR TITLE
Handle case when response does not have original respose

### DIFF
--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -176,6 +176,11 @@ class RestApiResponse(object):
         return self.status
 
     def raise_for_status(self, message=None):
+        if self._response is None:
+            if self._data and self._data.get("detail"):
+                raise ServerError(self._data["detail"])
+            raise ValueError("Response is not available.")
+
         try:
             self._response.raise_for_status()
         except requests.exceptions.HTTPError as exc:


### PR DESCRIPTION
## Description
When response object does not have original response and `raise_for_status` an understandable error is raised instead of None type does not have attribute.