### PR TITLE
Use correct method in public 'get_default_settings_variant'

### DIFF
--- a/ayon_api/_api.py
+++ b/ayon_api/_api.py
@@ -374,7 +374,7 @@ def get_default_settings_variant():
     """
 
     con = get_server_api_connection()
-    return con.get_client_version()
+    return con.get_default_settings_variant()
 
 
 def set_default_settings_variant(variant):


### PR DESCRIPTION
## Description
Public function `get_default_settings_variant` uses correct method `get_default_settings_variant`.