### PR TITLE
Expect representation file size as string

### DIFF
--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -5079,7 +5079,6 @@ class ServerAPI(object):
             version = repre.pop("version")
             product = version.pop("product")
             folder = product.pop("folder")
-            self._convert_entity_data(repre)
             self._convert_entity_data(version)
             self._convert_entity_data(product)
             self._convert_entity_data(folder)

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -4841,6 +4841,15 @@ class ServerAPI(object):
                 context = json.loads(orig_context)
             representation["context"] = context
 
+        repre_files = representation.get("files")
+        if not repre_files:
+            return
+
+        for repre_file in repre_files:
+            repre_file_size = repre_file.get("size")
+            if repre_file_size is not None:
+                repre_file["size"] = int(repre_file["size"])
+
     def get_representations(
         self,
         project_name,

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -4897,7 +4897,9 @@ class ServerAPI(object):
             fields = set(fields)
             if "attrib" in fields:
                 fields.remove("attrib")
-                fields |= self.get_attributes_fields_for_type("representation")
+                fields |= self.get_attributes_fields_for_type(
+                    "representation"
+                )
 
         use_rest = False
         if "data" in fields and not self.graphql_allows_data_in_query:

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -4833,6 +4833,14 @@ class ServerAPI(object):
         )
         return latest_version["id"] == version_id
 
+    def _representation_conversion(self, representation):
+        if "context" in representation:
+            orig_context = representation["context"]
+            context = {}
+            if orig_context and orig_context != "null":
+                context = json.loads(orig_context)
+            representation["context"] = context
+
     def get_representations(
         self,
         project_name,
@@ -4949,12 +4957,7 @@ class ServerAPI(object):
                 else:
                     self._convert_entity_data(repre)
 
-                if "context" in repre:
-                    orig_context = repre["context"]
-                    context = {}
-                    if orig_context and orig_context != "null":
-                        context = json.loads(orig_context)
-                    repre["context"] = context
+                self._representation_conversion(repre)
 
                 if own_attributes:
                     fill_own_attribs(repre)


### PR DESCRIPTION
## Description
We'll need to use string for file size of representation because GraphQl supports only 32-bit int.

## Additional information
The size is always converted to `int` > it is not necessary to handle server versions, if it was already int nothing really happens.