### PR TITLE
Entity hub: Fix folder creation

### DIFF
--- a/ayon_api/entity_hub.py
+++ b/ayon_api/entity_hub.py
@@ -2549,7 +2549,10 @@ class FolderEntity(BaseEntity):
         if self.thumbnail_id is not UNKNOWN_VALUE:
             output["thumbnailId"] = self.thumbnail_id
 
-        if self._entity_hub.allow_data_changes:
+        if (
+            self._entity_hub.allow_data_changes
+            and self._data is not UNKNOWN_VALUE
+        ):
             output["data"] = self._data
         return output
 


### PR DESCRIPTION
## Description
Do not pass 'data' to create body if value is `UNKNOWN_VALUE`.

### Additional information
This issue is already captured in `TaskEntity` but not in `FolderEntity`.