### PR TITLE
Fix get last versions function

### DIFF
--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -4719,7 +4719,7 @@ class ServerAPI(object):
             own_attributes=own_attributes
         )
         return {
-            version["parent"]: version
+            version["productId"]: version
             for version in versions
         }
 


### PR DESCRIPTION
## Description
Use correct key `productId` instead of `parent` when mapping versions by parent id.