### PR TITLE
GraphQlQueryFailed exception path conversion

### DIFF
--- a/ayon_api/exceptions.py
+++ b/ayon_api/exceptions.py
@@ -53,7 +53,10 @@ class GraphQlQueryFailed(Exception):
             msg = error["message"]
             path = error.get("path")
             if path:
-                msg += " on item '{}'".format("/".join(path))
+                msg += " on item '{}'".format("/".join(
+                    # Convert to string
+                    str(x) for x in path
+                ))
             locations = error.get("locations")
             if locations:
                 _locations = [


### PR DESCRIPTION
## Description
Make sure all path items from error are strings.