### PR TITLE
Fix default project creation without anatomy preset name

### DIFF
--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -2731,7 +2731,7 @@ class ServerAPI(object):
             dict[str, Any]: Anatomy preset values.
 
         """
-        if preset_name is None:
+        if not preset_name:
             preset_name = self.get_default_anatomy_preset_name()
         result = self.get("anatomy/presets/{}".format(preset_name))
         result.raise_for_status()


### PR DESCRIPTION
When creating a project through the API the primary preset wasn't being applied. Changing the conditional to not just check for `None` seems to fix it.

**How to test**

* Create a primary anatomy preset different from default `_`
* Call ayon_api to create project without passing preset name (i.e., `ayon_api.create_project("dev_004", "dev_004", False)`)