### PR TITLE
Preset name: Use primary and builtin preset name placeholders

### DIFF
--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -2733,7 +2733,11 @@ class ServerAPI(object):
 
         """
         if preset_name is None:
-            preset_name = self.get_default_anatomy_preset_name()
+            preset_name = "__primary__"
+            major, minor, patch, _, _ = self.server_version_tuple
+            if (major, minor, patch) < (1, 0, 8):
+                preset_name = self.get_default_anatomy_preset_name()
+
         result = self.get("anatomy/presets/{}".format(preset_name))
         result.raise_for_status()
         return result.data

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -2749,7 +2749,11 @@ class ServerAPI(object):
             dict[str, Any]: Built-in anatomy preset.
 
         """
-        return self.get_project_anatomy_preset("_")
+        preset_name = "__builtin__"
+        major, minor, patch, _, _ = self.server_version_tuple
+        if (major, minor, patch) < (1, 0, 8):
+            preset_name = "_"
+        return self.get_project_anatomy_preset(preset_name)
 
     def get_project_roots_by_site(self, project_name):
         """Root overrides per site name.


### PR DESCRIPTION
## Description
AYON server 1.0.8 added support for `__primary__` and `__builtin__` preset placeholders to easier get the coresponding value. The values can be used with the api.