### PR TITLE
Entity hub: Use task fields to fetch tasks

### DIFF
--- a/ayon_api/entity_hub.py
+++ b/ayon_api/entity_hub.py
@@ -219,6 +219,7 @@ class EntityHub(object):
                 entity_data = self._connection.get_task_by_id(
                     self.project_name,
                     entity_id,
+                    fields=self._get_task_fields(),
                     own_attributes=True
                 )
             else:


### PR DESCRIPTION
## Description
Using `get_or_query_entity_by_id` does not use tasks fields defined by entity hub which causes error when creating `TaskEntity` from data.