### PR TITLE
Chore: Added 'status' and 'tags' to default fields

### DIFF
--- a/ayon_api/constants.py
+++ b/ayon_api/constants.py
@@ -72,6 +72,8 @@ DEFAULT_FOLDER_FIELDS = {
     "active",
     "thumbnailId",
     "data",
+    "status",
+    "tags",
 }
 
 # --- Tasks ---
@@ -84,6 +86,8 @@ DEFAULT_TASK_FIELDS = {
     "active",
     "assignees",
     "data",
+    "status",
+    "tags",
 }
 
 # --- Products ---
@@ -94,6 +98,8 @@ DEFAULT_PRODUCT_FIELDS = {
     "active",
     "productType",
     "data",
+    "status",
+    "tags",
 }
 
 # --- Versions ---
@@ -109,6 +115,8 @@ DEFAULT_VERSION_FIELDS = {
     "createdAt",
     "updatedAt",
     "data",
+    "status",
+    "tags",
 }
 
 # --- Representations ---
@@ -120,6 +128,8 @@ DEFAULT_REPRESENTATION_FIELDS = {
     "active",
     "versionId",
     "data",
+    "status",
+    "tags",
 }
 
 REPRESENTATION_FILES_FIELDS = {
@@ -144,6 +154,8 @@ DEFAULT_WORKFILE_INFO_FIELDS = {
     "updatedAt",
     "updatedBy",
     "data",
+    "status",
+    "tags",
 }
 
 DEFAULT_EVENT_FIELDS = {

--- a/ayon_api/entity_hub.py
+++ b/ayon_api/entity_hub.py
@@ -605,15 +605,12 @@ class EntityHub(object):
         folder_fields.add("hasProducts")
         if self._allow_data_changes:
             folder_fields.add("data")
-        folder_fields |= {"status", "tags"}
         return folder_fields
 
     def _get_task_fields(self):
-        task_fields = set(
+        return set(
             self._connection.get_default_fields_for_type("task")
         )
-        task_fields |= {"status", "tags"}
-        return task_fields
 
     def query_entities_from_server(self):
         """Query whole project at once."""


### PR DESCRIPTION
## Description
All entities do support `"status"` and `"tags"` in fields, which are now fetched by default.