### PR TITLE
Repre Hierarchy: Fetch also task entity

### DIFF
--- a/ayon_api/_api.py
+++ b/ayon_api/_api.py
@@ -3345,6 +3345,7 @@ def get_representations_hierarchy(*args, **kwargs):
         representation_ids (Iterable[str]): Representation ids.
         project_fields (Optional[Iterable[str]]): Project fields.
         folder_fields (Optional[Iterable[str]]): Folder fields.
+        task_fields (Optional[Iterable[str]]): Task fields.
         product_fields (Optional[Iterable[str]]): Product fields.
         version_fields (Optional[Iterable[str]]): Version fields.
         representation_fields (Optional[Iterable[str]]): Representation
@@ -3369,6 +3370,7 @@ def get_representation_hierarchy(*args, **kwargs):
         representation_id (str): Representation id.
         project_fields (Optional[Iterable[str]]): Project fields.
         folder_fields (Optional[Iterable[str]]): Folder fields.
+        task_fields (Optional[Iterable[str]]): Task fields.
         product_fields (Optional[Iterable[str]]): Product fields.
         version_fields (Optional[Iterable[str]]): Version fields.
         representation_fields (Optional[Iterable[str]]): Representation

--- a/ayon_api/graphql_queries.py
+++ b/ayon_api/graphql_queries.py
@@ -466,6 +466,7 @@ def representations_parents_qraphql_query(
 
 def representations_hierarchy_qraphql_query(
     folder_fields,
+    task_fields,
     product_fields,
     version_fields,
     representation_fields,
@@ -486,11 +487,16 @@ def representations_hierarchy_qraphql_query(
 
     repres_field.set_filter("ids", repre_ids_var)
     version_field = None
-    if folder_fields or product_fields or version_fields:
+    if folder_fields or task_fields or product_fields or version_fields:
         version_field = repres_field.add_field("version")
         if version_fields:
             for key, value in fields_to_dict(version_fields).items():
                 fields_queue.append((key, value, version_field))
+
+    if task_fields:
+        task_field = version_field.add_field("task")
+        for key, value in fields_to_dict(task_fields).items():
+            fields_queue.append((key, value, task_field))
 
     product_field = None
     if folder_fields or product_fields:

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -6569,6 +6569,7 @@ class ServerAPI(object):
             representation_ids,
             project_fields=project_fields,
             folder_fields=folder_fields,
+            task_fields=set(),
             product_fields=product_fields,
             version_fields=version_fields,
             representation_fields={"id"},

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -6381,6 +6381,7 @@ class ServerAPI(object):
         representation_ids,
         project_fields=None,
         folder_fields=None,
+        task_fields=None,
         product_fields=None,
         version_fields=None,
         representation_fields=None,
@@ -6398,6 +6399,7 @@ class ServerAPI(object):
             representation_ids (Iterable[str]): Representation ids.
             project_fields (Optional[Iterable[str]]): Project fields.
             folder_fields (Optional[Iterable[str]]): Folder fields.
+            task_fields (Optional[Iterable[str]]): Task fields.
             product_fields (Optional[Iterable[str]]): Product fields.
             version_fields (Optional[Iterable[str]]): Version fields.
             representation_fields (Optional[Iterable[str]]): Representation
@@ -6428,7 +6430,7 @@ class ServerAPI(object):
         repre_ids = set(representation_ids)
         output = {
             repre_id: RepresentationHierarchy(
-                project, None, None, None, None
+                project, None, None, None, None, None
             )
             for repre_id in representation_ids
         }
@@ -6437,6 +6439,11 @@ class ServerAPI(object):
             folder_fields = self.get_default_fields_for_type("folder")
         else:
             folder_fields = set(folder_fields)
+
+        if task_fields is None:
+            task_fields = self.get_default_fields_for_type("task")
+        else:
+            task_fields = set(task_fields)
 
         if product_fields is None:
             product_fields = self.get_default_fields_for_type("product")
@@ -6459,6 +6466,7 @@ class ServerAPI(object):
 
         query = representations_hierarchy_qraphql_query(
             folder_fields,
+            task_fields,
             product_fields,
             version_fields,
             representation_fields,
@@ -6471,12 +6479,16 @@ class ServerAPI(object):
             repre_id = repre["id"]
             version = repre.pop("version", {})
             product = version.pop("product", {})
+            task = version.pop("task", None)
             folder = product.pop("folder", {})
             self._convert_entity_data(version)
             self._convert_entity_data(product)
             self._convert_entity_data(folder)
+            if task:
+                self._convert_entity_data(task)
+
             output[repre_id] = RepresentationHierarchy(
-                project, folder, product, version, repre
+                project, folder, task, product, version, repre
             )
 
         return output
@@ -6487,6 +6499,7 @@ class ServerAPI(object):
         representation_id,
         project_fields=None,
         folder_fields=None,
+        task_fields=None,
         product_fields=None,
         version_fields=None,
         representation_fields=None,
@@ -6500,6 +6513,7 @@ class ServerAPI(object):
             representation_id (str): Representation id.
             project_fields (Optional[Iterable[str]]): Project fields.
             folder_fields (Optional[Iterable[str]]): Folder fields.
+            task_fields (Optional[Iterable[str]]): Task fields.
             product_fields (Optional[Iterable[str]]): Product fields.
             version_fields (Optional[Iterable[str]]): Version fields.
             representation_fields (Optional[Iterable[str]]): Representation
@@ -6517,6 +6531,7 @@ class ServerAPI(object):
             [representation_id],
             project_fields=project_fields,
             folder_fields=folder_fields,
+            task_fields=task_fields,
             product_fields=product_fields,
             version_fields=version_fields,
             representation_fields=representation_fields,

--- a/ayon_api/utils.py
+++ b/ayon_api/utils.py
@@ -29,7 +29,14 @@ RepresentationParents = collections.namedtuple(
 
 RepresentationHierarchy = collections.namedtuple(
     "RepresentationHierarchy",
-    ("project", "folder", "product", "version", "representation")
+    (
+        "project",
+        "folder",
+        "task",
+        "product",
+        "version",
+        "representation",
+    )
 )
 
 


### PR DESCRIPTION
## Description
It is possible to fetch task entity with representation hierarchy.

## Additional information
The task entity is connected to version entity. Value of `task` is `None` If `"taskId"` is not set on version.