### PR TITLE
Data contains dictionary if value is empty

### DIFF
--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -8134,11 +8134,14 @@ class ServerAPI(object):
         return op_results
 
     def _convert_entity_data(self, entity):
-        if not entity:
+        if not entity or "data" not in entity:
             return
-        entity_data = entity.get("data")
-        if (
-            entity_data is not None
-            and isinstance(entity_data, str)
-        ):
-            entity["data"] = json.loads(entity_data)
+
+        entity_data = entity["data"]
+        if entity_data is None:
+            entity_data = {}
+
+        elif isinstance(entity_data, str):
+            entity_data = json.loads(entity_data)
+
+        entity["data"] = entity_data

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -8137,11 +8137,8 @@ class ServerAPI(object):
         if not entity or "data" not in entity:
             return
 
-        entity_data = entity["data"]
-        if entity_data is None:
-            entity_data = {}
-
-        elif isinstance(entity_data, str):
+        entity_data = entity["data"] or {}
+        if isinstance(entity_data, str):
             entity_data = json.loads(entity_data)
 
         entity["data"] = entity_data


### PR DESCRIPTION
## Description
Use empty dictionary when `"data"` value is `None`.

## Additional information
When data are empty on entity server does return `None` instead of `"{}"`, added functionality makes `None` value as dictionary.