### PR TITLE
Settings variant: Don't create connection to get default settings variant

### DIFF
--- a/ayon_api/_api.py
+++ b/ayon_api/_api.py
@@ -18,6 +18,9 @@ from .constants import (
 )
 from .server_api import ServerAPI
 from .exceptions import FailedServiceInit
+from .utils import (
+    get_default_settings_variant as _get_default_settings_variant
+)
 
 
 class GlobalServerAPI(ServerAPI):
@@ -502,6 +505,8 @@ def get_default_settings_variant():
         Union[str, None]: name of variant or None.
 
     """
+    if not GlobalContext.is_connection_created():
+        return _get_default_settings_variant()
     con = get_server_api_connection()
     return con.get_default_settings_variant()
 


### PR DESCRIPTION
## Changelog Description
Function `get_default_settings_variant` does not create connection if is not created yet.

## Testing notes:
1. Import and call `get_default_settings_variant` from `ayon_api`.
2. It should return settings variant even if `AYON_SERVER_URL` and `AYON_API_KEY` are not set.
