### PR TITLE
Representation hierarchy: Convert representation data

### DIFF
--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -6504,6 +6504,8 @@ class ServerAPI(object):
             product = version.pop("product", {})
             task = version.pop("task", None)
             folder = product.pop("folder", {})
+            self._convert_entity_data(repre)
+            self._representation_conversion(repre)
             self._convert_entity_data(version)
             self._convert_entity_data(product)
             self._convert_entity_data(folder)


### PR DESCRIPTION
## Changelog Description
Convert representation in `get_representations_hierarchy`.

## Testing notes:
1. Returned representations from `get_representations_hierarchy` have `"data"` as dictionary.

Resolves https://github.com/ynput/ayon-python-api/issues/178