### PR TITLE
Define package folder as it's not matching package name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ description = "AYON Python API"
 authors = [
     "ynput.io <info@ynput.io>"
 ]
+packages = [
+    { include = "ayon_api" }
+]
 
 [tool.poetry.dependencies]
 python = ">=3.6.5"


### PR DESCRIPTION
## Changelog Description
Specify package folder otherwise it fails to discover it given that it doesn't match the name:
```
Building wheels for collected packages: ayon-python-api
  Building wheel for ayon-python-api (pyproject.toml) ... error
  error: subprocess-exited-with-error
  
  × Building wheel for ayon-python-api (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [24 lines of output]
      Traceback (most recent call last):
        File "/pipe/dev/farrizabalaga/ayon-shotgrid/service_tools/venv/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/pipe/dev/farrizabalaga/ayon-shotgrid/service_tools/venv/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/pipe/dev/farrizabalaga/ayon-shotgrid/service_tools/venv/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 251, in build_wheel
          return _build_backend().build_wheel(wheel_directory, config_settings,
        File "/tmp/pip-build-env-8exbcjx1/overlay/lib/python3.10/site-packages/poetry/core/masonry/api.py", line 58, in build_wheel
          return WheelBuilder.make_in(
        File "/tmp/pip-build-env-8exbcjx1/overlay/lib/python3.10/site-packages/poetry/core/masonry/builders/wheel.py", line 88, in make_in
          wb.build(target_dir=directory)
        File "/tmp/pip-build-env-8exbcjx1/overlay/lib/python3.10/site-packages/poetry/core/masonry/builders/wheel.py", line 124, in build
          self._copy_module(zip_file)
        File "/tmp/pip-build-env-8exbcjx1/overlay/lib/python3.10/site-packages/poetry/core/masonry/builders/wheel.py", line 265, in _copy_module
          to_add = self.find_files_to_add()
        File "/tmp/pip-build-env-8exbcjx1/overlay/lib/python3.10/site-packages/poetry/core/masonry/builders/builder.py", line 171, in find_files_to_add
          for include in self._module.includes:
        File "/home/farrizabalaga/.pyenv/versions/3.10.14/lib/python3.10/functools.py", line 981, in __get__
          val = self.func(instance)
        File "/tmp/pip-build-env-8exbcjx1/overlay/lib/python3.10/site-packages/poetry/core/masonry/builders/builder.py", line 97, in _module
          return Module(
        File "/tmp/pip-build-env-8exbcjx1/overlay/lib/python3.10/site-packages/poetry/core/masonry/utils/module.py", line 65, in __init__
          raise ModuleOrPackageNotFound(
      poetry.core.masonry.utils.module.ModuleOrPackageNotFound: No file/folder found for package ayon-python-api
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for ayon-python-api
Failed to build ayon-python-api
ERROR: Could not build wheels for ayon-python-api, which is required to install pyproject.toml-based projects
```

## Testing notes:

1. Try to run pip install on the package folder (i.e. `pip install /source/ayon-python-api`)