### PR TITLE
Workfiles info: Convert workfile info data to dictionary

### DIFF
--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -6965,6 +6965,7 @@ class ServerAPI(object):
 
         for parsed_data in query.continuous_query(self):
             for workfile_info in parsed_data["project"]["workfiles"]:
+                self._convert_entity_data(workfile_info)
                 yield workfile_info
 
     def get_workfile_info(


### PR DESCRIPTION
## Changelog Description
Field `"data"` in workfile info entity is converted to dictionary.

## Additional info
The `"data"` on entities are returned as json string from AYON server. For other entities it is already converted, workfile info was missing.

## Testing notes:
1. Each entity received using `get_workfiles_info` or `get_workfile_info` should have `"data"` as dictionary.

Resolves https://github.com/ynput/ayon-python-api/issues/187