### PR TITLE
Chore: Automated api does not copy 'get_default_settings_variant'

### DIFF
--- a/automated_api.py
+++ b/automated_api.py
@@ -27,6 +27,7 @@ from ayon_api import ServerAPI  # noqa: E402
 
 EXCLUDED_METHODS = {
     "get_default_service_username",
+    "get_default_settings_variant",
     "validate_token",
     "set_token",
     "reset_token",

--- a/ayon_api/_api.py
+++ b/ayon_api/_api.py
@@ -331,6 +331,20 @@ def get_server_api_connection():
     """
     return GlobalContext.get_server_api_connection()
 
+
+def get_default_settings_variant():
+    """Default variant used for settings.
+
+    Returns:
+        Union[str, None]: name of variant or None.
+
+    """
+    if not GlobalContext.is_connection_created():
+        return _get_default_settings_variant()
+    con = get_server_api_connection()
+    return con.get_default_settings_variant()
+
+
 # ------------------------------------------------
 #     This content is generated automatically.
 # ------------------------------------------------
@@ -496,19 +510,6 @@ def set_client_version(*args, **kwargs):
     """
     con = get_server_api_connection()
     return con.set_client_version(*args, **kwargs)
-
-
-def get_default_settings_variant():
-    """Default variant used for settings.
-
-    Returns:
-        Union[str, None]: name of variant or None.
-
-    """
-    if not GlobalContext.is_connection_created():
-        return _get_default_settings_variant()
-    con = get_server_api_connection()
-    return con.get_default_settings_variant()
 
 
 def set_default_settings_variant(*args, **kwargs):


### PR DESCRIPTION
## Changelog Description
Do not copy 'get_default_settings_variant' on auto api creation.

## Additional info
The function has custom implementation in `_api.py`.

## Testing notes:
1. Running `automated_api.py` script should not cause any changes in `_api.py`.
