### PR TITLE
Chore: Fix typo and typhint in get representations

### DIFF
--- a/ayon_api/_api.py
+++ b/ayon_api/_api.py
@@ -3405,9 +3405,9 @@ def get_representations(*args, **kwargs):
         version_ids (Optional[Iterable[str]]): Version ids used for
             representation filtering. Versions are parents of
             representations.
-        names_by_version_ids (Optional[bool]): Find representations
-            by names and version ids. This filter discard all
-            other filters.
+        names_by_version_ids (Optional[Dict[str, Iterable[str]]): Find
+            representations by names and version ids. This filter
+            discard all other filters.
         statuses (Optional[Iterable[str]]): Representation statuses used
             for filtering.
         tags (Optional[Iterable[str]]): Representation tags used

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -6374,9 +6374,9 @@ class ServerAPI(object):
             version_ids (Optional[Iterable[str]]): Version ids used for
                 representation filtering. Versions are parents of
                 representations.
-            names_by_version_ids (Optional[bool]): Find representations
-                by names and version ids. This filter discard all
-                other filters.
+            names_by_version_ids (Optional[Dict[str, Iterable[str]]): Find
+                representations by names and version ids. This filter
+                discard all other filters.
             statuses (Optional[Iterable[str]]): Representation statuses used
                 for filtering.
             tags (Optional[Iterable[str]]): Representation tags used
@@ -6438,21 +6438,21 @@ class ServerAPI(object):
             filters["representationIds"] = list(representation_ids)
 
         version_ids_filter = None
-        representaion_names_filter = None
+        representation_names_filter = None
         if names_by_version_ids is not None:
             version_ids_filter = set()
-            representaion_names_filter = set()
+            representation_names_filter = set()
             for version_id, names in names_by_version_ids.items():
                 version_ids_filter.add(version_id)
-                representaion_names_filter |= set(names)
+                representation_names_filter |= set(names)
 
-            if not version_ids_filter or not representaion_names_filter:
+            if not version_ids_filter or not representation_names_filter:
                 return
 
         else:
             if representation_names is not None:
-                representaion_names_filter = set(representation_names)
-                if not representaion_names_filter:
+                representation_names_filter = set(representation_names)
+                if not representation_names_filter:
                     return
 
             if version_ids is not None:
@@ -6463,8 +6463,8 @@ class ServerAPI(object):
         if version_ids_filter:
             filters["versionIds"] = list(version_ids_filter)
 
-        if representaion_names_filter:
-            filters["representationNames"] = list(representaion_names_filter)
+        if representation_names_filter:
+            filters["representationNames"] = list(representation_names_filter)
 
         if statuses is not None:
             statuses = set(statuses)


### PR DESCRIPTION
## Changelog Description
Define correct typehint for `names_by_version_ids` and fix typo `representaion_names_filter` > `representation_names_filter`.

## Testing notes:
1. Verify changes.
