### PR TITLE
WebAction: Use abort endpoint instead of take

### DIFF
--- a/ayon_api/utils.py
+++ b/ayon_api/utils.py
@@ -881,7 +881,7 @@ def abort_web_action_event(
 
     """
     response = requests.post(
-        f"{server_url}/api/actions/take/{action_token}",
+        f"{server_url}/api/actions/abort/{action_token}",
         json={"message": reason},
     )
     response.raise_for_status()


### PR DESCRIPTION
## Changelog Description
Use correct endpoint to abord action.
