### PR TITLE
Chore: As username stack works

### DIFF
--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -859,12 +859,12 @@ class ServerAPI(object):
                 "Can't set service username. API key is not a service token."
             )
 
-        with self._as_user_stack.as_user(username) as o:
-            self._update_session_headers()
-            try:
-                yield o
-            finally:
+        try:
+            with self._as_user_stack.as_user(username) as o:
                 self._update_session_headers()
+                yield o
+        finally:
+            self._update_session_headers()
 
     @property
     def is_server_available(self):


### PR DESCRIPTION
## Changelog Description
As username stack now reverts to previous user correctly.

## Additional review information
As username functionality did not set the username to previouse username when context manager ended.

## Testing notes:
1. When using `as_username` stack on `ServerAPI` object it does return to previous user when ended.
