### PR TITLE
Chore: Raise an error if ignore sender types is not supported

### DIFF
--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -1761,9 +1761,13 @@ class ServerAPI(object):
             kwargs["ignoreOlderThan"] = ignore_older_than
         if (
             ignore_sender_types is not None
-            and (major, minor, patch) > (1, 5, 4)
         ):
-            kwargs["ignoreSenderTypes"] = ignore_sender_types
+            if (major, minor, patch) > (1, 5, 4):
+                raise ValueError(
+                    "Ignore sender types are not supported for"
+                    f" your version of server {self.server_version}."
+                )
+            kwargs["ignoreSenderTypes"] = list(ignore_sender_types)
 
         response = self.post("enroll", **kwargs)
         if response.status_code == 204:

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -1759,9 +1759,7 @@ class ServerAPI(object):
             and (major, minor, patch) > (1, 5, 1)
         ):
             kwargs["ignoreOlderThan"] = ignore_older_than
-        if (
-            ignore_sender_types is not None
-        ):
+        if ignore_sender_types is not None:
             if (major, minor, patch) > (1, 5, 4):
                 raise ValueError(
                     "Ignore sender types are not supported for"


### PR DESCRIPTION
## Changelog Description
ServerAPI raises error if ignore sender types is not supported.

## Additional review information
Right now passing ignore sender types silently does not ignore the fact that the filtering is not supported by server and raises an error.

## Testing notes:
1. Use server older than 1.5.5 and user enroll job with ignore sender types.
2. It should crash.