### PR TITLE
As username functionality can ignore service user error

### DIFF
--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -842,13 +842,15 @@ class ServerAPI(object):
             self._update_session_headers()
 
     @contextmanager
-    def as_username(self, username):
+    def as_username(self, username, ignore_service_error=False):
         """Service API will temporarily work as other user.
 
         This method can be used only if service API key is logged in.
 
         Args:
             username (Union[str, None]): Username to work as when service.
+            ignore_service_error (Optional[bool]): Ignore error when service
+                API key is not used.
 
         Raises:
             ValueError: When connection is not yet authenticated or api key
@@ -861,6 +863,9 @@ class ServerAPI(object):
             )
 
         if not self._access_token_is_service:
+            if ignore_service_error:
+                yield None
+                return
             raise ValueError(
                 "Can't set service username. API key is not a service token."
             )


### PR DESCRIPTION
## Changelog Description
It is possible to run `as_username` contextmanager and ignore error if used api key is not a service api key.

## Additional review information
Sometimes the functionality to work as other user is not mandatory and can be done even if is not running as service user. Maintining that in code is hard because to work as other user a context manager must be used which complicates the code below it a lot.

## Testing notes:
1. It is possible to use `with api.as_username("someuser", ignore_service_error=True)` event if API key is not service API key.
