### PR TITLE
Events: Use statuses for events filtering

### DIFF
--- a/ayon_api/_api.py
+++ b/ayon_api/_api.py
@@ -874,13 +874,14 @@ def get_events(
     topics=None,
     event_ids=None,
     project_names=None,
-    states=None,
+    statuses=None,
     users=None,
     include_logs=None,
     has_children=None,
     newer_than=None,
     older_than=None,
     fields=None,
+    states=None,
 ):
     """Get events from server with filtering options.
 
@@ -892,7 +893,7 @@ def get_events(
         event_ids (Optional[Iterable[str]]): Event ids.
         project_names (Optional[Iterable[str]]): Project on which
             event happened.
-        states (Optional[Iterable[str]]): Filtering by states.
+        statuses (Optional[Iterable[str]]): Filtering by statuses.
         users (Optional[Iterable[str]]): Filtering by users
             who created/triggered an event.
         include_logs (Optional[bool]): Query also log events.
@@ -904,6 +905,8 @@ def get_events(
             iso datetime string.
         fields (Optional[Iterable[str]]): Fields that should be received
             for each event.
+        states (Optional[Iterable[str]]): DEPRECATED Filtering by states.
+            Use 'statuses' instead.
 
     Returns:
         Generator[dict[str, Any]]: Available events matching filters.
@@ -914,13 +917,14 @@ def get_events(
         topics=topics,
         event_ids=event_ids,
         project_names=project_names,
-        states=states,
+        statuses=statuses,
         users=users,
         include_logs=include_logs,
         has_children=has_children,
         newer_than=newer_than,
         older_than=older_than,
         fields=fields,
+        states=states,
     )
 
 

--- a/ayon_api/_api.py
+++ b/ayon_api/_api.py
@@ -871,17 +871,17 @@ def get_event(
 
 
 def get_events(
-    topics=None,
-    event_ids=None,
-    project_names=None,
-    statuses=None,
-    users=None,
-    include_logs=None,
-    has_children=None,
-    newer_than=None,
-    older_than=None,
-    fields=None,
-    states=None,
+    topics: Optional[Iterable[str]] = None,
+    event_ids: Optional[Iterable[str]] = None,
+    project_names: Optional[Iterable[str]] = None,
+    statuses: Optional[Iterable[str]] = None,
+    users: Optional[Iterable[str]] = None,
+    include_logs: Optional[bool] = None,
+    has_children: Optional[bool] = None,
+    newer_than: Optional[str] = None,
+    older_than: Optional[str] = None,
+    fields: Optional[Iterable[str]] = None,
+    states: Optional[Iterable[str]] = None,
 ):
     """Get events from server with filtering options.
 

--- a/ayon_api/graphql_queries.py
+++ b/ayon_api/graphql_queries.py
@@ -570,23 +570,26 @@ def workfiles_info_graphql_query(fields):
     return query
 
 
-def events_graphql_query(fields):
+def events_graphql_query(fields, use_states=False):
     query = GraphQlQuery("Events")
     topics_var = query.add_variable("eventTopics", "[String!]")
     ids_var = query.add_variable("eventIds", "[String!]")
     projects_var = query.add_variable("projectNames", "[String!]")
-    states_var = query.add_variable("eventStates", "[String!]")
+    statuses_var = query.add_variable("eventStatuses", "[String!]")
     users_var = query.add_variable("eventUsers", "[String!]")
     include_logs_var = query.add_variable("includeLogsFilter", "Boolean!")
     has_children_var = query.add_variable("hasChildrenFilter", "Boolean!")
     newer_than_var = query.add_variable("newerThanFilter", "String!")
     older_than_var = query.add_variable("olderThanFilter", "String!")
 
+    statuses_filter_name = "statuses"
+    if use_states:
+        statuses_filter_name = "states"
     events_field = query.add_field_with_edges("events")
     events_field.set_filter("ids", ids_var)
     events_field.set_filter("topics", topics_var)
     events_field.set_filter("projects", projects_var)
-    events_field.set_filter("states", states_var)
+    events_field.set_filter(statuses_filter_name, statuses_var)
     events_field.set_filter("users", users_var)
     events_field.set_filter("includeLogs", include_logs_var)
     events_field.set_filter("hasChildren", has_children_var)

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -1455,17 +1455,17 @@ class ServerAPI(object):
 
     def get_events(
         self,
-        topics=None,
-        event_ids=None,
-        project_names=None,
-        statuses=None,
-        users=None,
-        include_logs=None,
-        has_children=None,
-        newer_than=None,
-        older_than=None,
-        fields=None,
-        states=None,
+        topics: Optional[Iterable[str]] = None,
+        event_ids: Optional[Iterable[str]] = None,
+        project_names: Optional[Iterable[str]] = None,
+        statuses: Optional[Iterable[str]] = None,
+        users: Optional[Iterable[str]] = None,
+        include_logs: Optional[bool] = None,
+        has_children: Optional[bool] = None,
+        newer_than: Optional[str] = None,
+        older_than: Optional[str] = None,
+        fields: Optional[Iterable[str]] = None,
+        states: Optional[Iterable[str]] = None,
     ):
         """Get events from server with filtering options.
 


### PR DESCRIPTION
## Changelog Description
Use `statuses` instead of `states` for events filtering.

## Additional review information
The `statuses` fitler is available in current develop (first release after 1.5.6) where `states` becomes deprecated filter and should not be used anymore.

Use `statuses` as default argument in `get_events`, but still support `states` with deprecation warning.

## Testing notes:
1. Use `statuses` in `get_events`.
2. It should automatically use `states` or `statuses` GraphQl filter based on server version.
