### PR TITLE
Return task id when creating a task using the create task function

### DIFF
--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -5469,7 +5469,7 @@ class ServerAPI(object):
             **create_data
         )
         response.raise_for_status()
-        return folder_id
+        return task_id
 
     def update_task(
         self,


### PR DESCRIPTION
## Changelog Description
Returns the task id when creating the task instead of the folder id

## Additional review information
changed the return from folder id to task id 

Resolves https://github.com/ynput/ayon-python-api/issues/214
