### PR TITLE
GraphQl: Limit and sorting options

### DIFF
--- a/ayon_api/__init__.py
+++ b/ayon_api/__init__.py
@@ -9,6 +9,7 @@ from .utils import (
     login_to_server,
     take_web_action_event,
     abort_web_action_event,
+    SortOrder,
 )
 from .server_api import (
     RequestTypes,
@@ -255,6 +256,7 @@ __all__ = (
     "login_to_server",
     "take_web_action_event",
     "abort_web_action_event",
+    "SortOrder",
 
     "RequestTypes",
     "ServerAPI",

--- a/ayon_api/graphql_queries.py
+++ b/ayon_api/graphql_queries.py
@@ -570,8 +570,8 @@ def workfiles_info_graphql_query(fields):
     return query
 
 
-def events_graphql_query(fields, use_states=False):
-    query = GraphQlQuery("Events")
+def events_graphql_query(fields, order, use_states=False):
+    query = GraphQlQuery("Events", order=order)
     topics_var = query.add_variable("eventTopics", "[String!]")
     ids_var = query.add_variable("eventIds", "[String!]")
     projects_var = query.add_variable("projectNames", "[String!]")
@@ -581,6 +581,8 @@ def events_graphql_query(fields, use_states=False):
     has_children_var = query.add_variable("hasChildrenFilter", "Boolean!")
     newer_than_var = query.add_variable("newerThanFilter", "String!")
     older_than_var = query.add_variable("olderThanFilter", "String!")
+    first_var = query.add_variable("firstFilter", "Int")
+    last_var = query.add_variable("lastFilter", "Int")
 
     statuses_filter_name = "statuses"
     if use_states:
@@ -595,6 +597,8 @@ def events_graphql_query(fields, use_states=False):
     events_field.set_filter("hasChildren", has_children_var)
     events_field.set_filter("newerThan", newer_than_var)
     events_field.set_filter("olderThan", older_than_var)
+    events_field.set_filter("first", first_var)
+    events_field.set_filter("last", last_var)
 
     nested_fields = fields_to_dict(set(fields))
 
@@ -641,8 +645,8 @@ def users_graphql_query(fields):
     return query
 
 
-def activities_graphql_query(fields):
-    query = GraphQlQuery("Activities")
+def activities_graphql_query(fields, order):
+    query = GraphQlQuery("Activities", order=order)
     project_name_var = query.add_variable("projectName", "String!")
     activity_ids_var = query.add_variable("activityIds", "[String!]")
     activity_types_var = query.add_variable("activityTypes", "[String!]")

--- a/ayon_api/utils.py
+++ b/ayon_api/utils.py
@@ -7,6 +7,7 @@ import platform
 import collections
 from urllib.parse import urlparse, urlencode
 from typing import Optional, Dict, Any
+from enum import IntEnum
 
 import requests
 import unidecode
@@ -39,6 +40,20 @@ RepresentationHierarchy = collections.namedtuple(
         "representation",
     )
 )
+
+
+class SortOrder(IntEnum):
+    """Sort order for GraphQl requests."""
+    ascending = 0
+    descending = 1
+
+    @classmethod
+    def parse_value(cls, value, default=None):
+        if value in (cls.ascending, "ascending", "asc"):
+            return cls.ascending
+        if value in (cls.descending, "descending", "desc"):
+            return cls.descending
+        return default
 
 
 def get_default_timeout():


### PR DESCRIPTION
## Changelog Description
GraphQl now does support to define limit of fetched entities and order in which are fetched.

## Additional review information
The new functionality was added for events and activilities methods as they might have actuall use-case.

## Testing notes:
1. Call `get_events` -> you should get many events sorted by ascending order based on creation date.
2. Call `get_events` with `limit` set to 10 -> you should get first 10 events available in your server.
3. Call `get_events` with `limit` set to 10 and order set to `SortOrder.descending` -> you should get last 10 events available in your server.
