### PR TITLE
Chore: Use f-string in server api

### DIFF
--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -2936,7 +2936,7 @@ class ServerAPI(object):
         if query_fields:
             query = "?{}".format(",".join(query_fields))
 
-        response = self.get("desktop/installers{}".format(query))
+        response = self.get(f"desktop/installers{query}")
         response.raise_for_status()
         return response.data
 
@@ -4158,7 +4158,7 @@ class ServerAPI(object):
                 query_values["site_id"] = site_id
 
         query = prepare_query_string(query_values)
-        response = self.get("settings{}".format(query))
+        response = self.get(f"settings{query}")
         response.raise_for_status()
         return response.data
 

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -276,7 +276,7 @@ class RestApiResponse(object):
         return key in self.data
 
     def __repr__(self):
-        return "<{} [{}]>".format(self.__class__.__name__, self.status)
+        return f"<{self.__class__.__name__} [{self.status}]>"
 
     def __len__(self):
         return int(200 <= self.status < 400)
@@ -308,10 +308,9 @@ class GraphQlResponse:
 
     def __repr__(self):
         if self.errors:
-            return "<{} errors={}>".format(
-                self.__class__.__name__, self.errors[0]['message']
-            )
-        return "<{}>".format(self.__class__.__name__)
+            message = self.errors[0]["message"]
+            return f"<{self.__class__.__name__} errors={message}>"
+        return f"<{self.__class__.__name__}>"
 
 
 def fill_own_attribs(entity):
@@ -469,12 +468,12 @@ class ServerAPI(object):
         max_retries: Optional[int] = None,
     ):
         if not base_url:
-            raise ValueError("Invalid server URL {}".format(str(base_url)))
+            raise ValueError(f"Invalid server URL {str(base_url)}")
 
         base_url = base_url.rstrip("/")
         self._base_url: str = base_url
-        self._rest_url: str = "{}/api".format(base_url)
-        self._graphql_url: str = "{}/graphql".format(base_url)
+        self._rest_url: str = f"{base_url}/api"
+        self._graphql_url: str = f"{base_url}/graphql"
         self._log: logging.Logger = logging.getLogger(self.__class__.__name__)
         self._access_token: Optional[str] = token
         # Allow to have 'site_id' to 'None'
@@ -933,9 +932,9 @@ class ServerAPI(object):
 
     def validate_server_availability(self):
         if not self.is_server_available:
-            raise ServerNotReached("Server \"{}\" can't be reached".format(
-                self._base_url
-            ))
+            raise ServerNotReached(
+                f"Server \"{self._base_url}\" can't be reached"
+            )
 
     def validate_token(self) -> bool:
         try:
@@ -1230,7 +1229,7 @@ class ServerAPI(object):
                 raise UnauthorizedError("User is not authorized.")
             return output
 
-        response = self.get("users/{}".format(username))
+        response = self.get(f"users/{username}")
         response.raise_for_status()
         return response.data
 
@@ -1264,8 +1263,7 @@ class ServerAPI(object):
                 if username:
                     headers["X-as-user"] = username
             else:
-                headers["Authorization"] = "Bearer {}".format(
-                    self._access_token)
+                headers["Authorization"] = f"Bearer {self._access_token}"
         return headers
 
     def login(
@@ -1312,9 +1310,9 @@ class ServerAPI(object):
                 _detail = response.data.get("detail")
                 details = ""
                 if _detail:
-                    details = " {}".format(_detail)
+                    details = f" {_detail}"
 
-                raise AuthenticationError("Login failed {}".format(details))
+                raise AuthenticationError(f"Login failed {details}")
 
         finally:
             self._token_validation_started = False
@@ -1427,12 +1425,12 @@ class ServerAPI(object):
         else:
             new_response = RestApiResponse(response)
 
-        self.log.debug("Response {}".format(str(new_response)))
+        self.log.debug(f"Response {str(new_response)}")
         return new_response
 
     def raw_post(self, entrypoint: str, **kwargs):
         url = self._endpoint_to_url(entrypoint)
-        self.log.debug("Executing [POST] {}".format(url))
+        self.log.debug(f"Executing [POST] {url}")
         return self._do_rest_request(
             RequestTypes.post,
             url,
@@ -1441,7 +1439,7 @@ class ServerAPI(object):
 
     def raw_put(self, entrypoint: str, **kwargs):
         url = self._endpoint_to_url(entrypoint)
-        self.log.debug("Executing [PUT] {}".format(url))
+        self.log.debug(f"Executing [PUT] {url}")
         return self._do_rest_request(
             RequestTypes.put,
             url,
@@ -1450,7 +1448,7 @@ class ServerAPI(object):
 
     def raw_patch(self, entrypoint: str, **kwargs):
         url = self._endpoint_to_url(entrypoint)
-        self.log.debug("Executing [PATCH] {}".format(url))
+        self.log.debug(f"Executing [PATCH] {url}")
         return self._do_rest_request(
             RequestTypes.patch,
             url,
@@ -1459,7 +1457,7 @@ class ServerAPI(object):
 
     def raw_get(self, entrypoint: str, **kwargs):
         url = self._endpoint_to_url(entrypoint)
-        self.log.debug("Executing [GET] {}".format(url))
+        self.log.debug(f"Executing [GET] {url}")
         return self._do_rest_request(
             RequestTypes.get,
             url,
@@ -1468,7 +1466,7 @@ class ServerAPI(object):
 
     def raw_delete(self, entrypoint: str, **kwargs):
         url = self._endpoint_to_url(entrypoint)
-        self.log.debug("Executing [DELETE] {}".format(url))
+        self.log.debug(f"Executing [DELETE] {url}")
         return self._do_rest_request(
             RequestTypes.delete,
             url,
@@ -1503,7 +1501,7 @@ class ServerAPI(object):
             dict[str, Any]: Full event data.
 
         """
-        response = self.get("events/{}".format(event_id))
+        response = self.get(f"events/{event_id}")
         response.raise_for_status()
         return response.data
 
@@ -1660,16 +1658,16 @@ class ServerAPI(object):
                 args.append("progress")
             if retries is not None:
                 args.append("retries")
-            fields = ", ".join("'{}'".format(f) for f in args)
+            fields = ", ".join(f"'{f}'" for f in args)
             ending = "s" if len(args) > 1 else ""
-            raise ValueError((
-                 "Your server version '{}' does not support update"
-                 " of {} field{} on event. The fields are supported since"
-                 " server version '0.5'."
-            ).format(self.get_server_version(), fields, ending))
+            raise ValueError(
+                 f"Your server version '{self.server_version}' does not"
+                 f" support update of {fields} field{ending} on event."
+                 " The fields are supported since server version '0.5'."
+            )
 
         response = self.patch(
-            "events/{}".format(event_id),
+            f"events/{event_id}",
             **kwargs
         )
         response.raise_for_status()
@@ -2545,7 +2543,7 @@ class ServerAPI(object):
             dict[str, Any]: Full server schema.
 
         """
-        url = "{}/openapi.json".format(self._base_url)
+        url = f"{self._base_url}/openapi.json"
         response = self._do_rest_request(RequestTypes.get, url)
         if response:
             return response.data
@@ -2605,7 +2603,7 @@ class ServerAPI(object):
                 position = len(attributes)
 
         response = self.put(
-            "attributes/{}".format(attribute_name),
+            f"attributes/{attribute_name}",
             data=data,
             scope=scope,
             position=position,
@@ -2614,9 +2612,8 @@ class ServerAPI(object):
         if response.status_code != 204:
             # TODO raise different exception
             raise ValueError(
-                "Attribute \"{}\" was not created/updated. {}".format(
-                    attribute_name, response.detail
-                )
+                f"Attribute \"{attribute_name}\" was not created/updated."
+                f" {response.detail}"
             )
 
         self.reset_attributes_schema()
@@ -2630,11 +2627,10 @@ class ServerAPI(object):
             attribute_name (str): Name of attribute to remove.
 
         """
-        response = self.delete("attributes/{}".format(attribute_name))
+        response = self.delete(f"attributes/{attribute_name}")
         response.raise_for_status(
-            "Attribute \"{}\" was not created/updated. {}".format(
-                attribute_name, response.detail
-            )
+            f"Attribute \"{attribute_name}\" was not created/updated."
+            f" {response.detail}"
         )
 
         self.reset_attributes_schema()
@@ -2703,7 +2699,7 @@ class ServerAPI(object):
         """
         attributes = self.get_attributes_for_type(entity_type)
         return {
-            "attrib.{}".format(attr)
+            f"attrib.{attr}"
             for attr in attributes
         }
 
@@ -2777,7 +2773,7 @@ class ServerAPI(object):
             entity_type_defaults = set(DEFAULT_USER_FIELDS)
 
         else:
-            raise ValueError("Unknown entity type \"{}\"".format(entity_type))
+            raise ValueError(f"Unknown entity type \"{entity_type}\"")
         return (
             entity_type_defaults
             | self.get_attributes_fields_for_type(entity_type)
@@ -2826,11 +2822,7 @@ class ServerAPI(object):
         ending = ""
         if subpaths:
             ending = "/{}".format("/".join(subpaths))
-        return "addons/{}/{}{}".format(
-            addon_name,
-            addon_version,
-            ending
-        )
+        return f"addons/{addon_name}/{addon_version}{ending}"
 
     def get_addon_url(
         self,
@@ -3013,7 +3005,7 @@ class ServerAPI(object):
 
         """
         response = self.patch(
-            "desktop/installers/{}".format(filename),
+            f"desktop/installers/{filename}",
             sources=sources
         )
         response.raise_for_status()
@@ -3025,7 +3017,7 @@ class ServerAPI(object):
             filename (str): Installer filename.
 
         """
-        response = self.delete("desktop/installers/{}".format(filename))
+        response = self.delete(f"desktop/installers/{filename}")
         response.raise_for_status()
 
     def download_installer(
@@ -3046,7 +3038,7 @@ class ServerAPI(object):
 
         """
         self.download_file(
-            "desktop/installers/{}".format(filename),
+            f"desktop/installers/{filename}",
             dst_filepath,
             chunk_size=chunk_size,
             progress=progress
@@ -3071,7 +3063,7 @@ class ServerAPI(object):
 
         """
         return self.upload_file(
-            "desktop/installers/{}".format(dst_filename),
+            f"desktop/installers/{dst_filename}",
             src_filepath,
             progress=progress
         )
@@ -3081,7 +3073,7 @@ class ServerAPI(object):
     ) -> str:
         endpoint = "desktop/dependencyPackages"
         if filename:
-            return "{}/{}".format(endpoint, filename)
+            return f"{endpoint}/{filename}"
         return endpoint
 
     def get_dependency_packages(self) -> "DependencyPackagesDict":
@@ -3665,7 +3657,7 @@ class ServerAPI(object):
             if (major, minor, patch) < (1, 0, 8):
                 preset_name = self.get_default_anatomy_preset_name()
 
-        result = self.get("anatomy/presets/{}".format(preset_name))
+        result = self.get(f"anatomy/presets/{preset_name}")
         result.raise_for_status()
         return result.data
 
@@ -3709,7 +3701,7 @@ class ServerAPI(object):
              dict[str, dict[str, str]]: Root values by root name by site id.
 
         """
-        result = self.get("projects/{}/roots".format(project_name))
+        result = self.get(f"projects/{project_name}/roots")
         result.raise_for_status()
         return result.data
 
@@ -3842,7 +3834,7 @@ class ServerAPI(object):
             for key, value in query_data.items()
         ]))
         response = self.get(
-            "projects/{}/siteRoots{}".format(project_name, query)
+            f"projects/{project_name}/siteRoots{query}"
         )
         response.raise_for_status()
         return response.data
@@ -3939,9 +3931,9 @@ class ServerAPI(object):
             dict[str, Any]: Schema of site settings.
 
         """
-        result = self.get("addons/{}/{}/siteSettings/schema".format(
-            addon_name, addon_version
-        ))
+        result = self.get(
+            f"addons/{addon_name}/{addon_version}/siteSettings/schema"
+        )
         result.raise_for_status()
         return result.data
 
@@ -4031,9 +4023,8 @@ class ServerAPI(object):
 
         query = prepare_query_string(query_items)
         result = self.get(
-            "addons/{}/{}/settings/{}{}".format(
-                addon_name, addon_version, project_name, query
-            )
+            f"addons/{addon_name}/{addon_version}"
+            f"/settings/{project_name}{query}"
         )
         result.raise_for_status()
         return result.data
@@ -4106,9 +4097,9 @@ class ServerAPI(object):
             return {}
 
         query = prepare_query_string({"site": site_id})
-        result = self.get("addons/{}/{}/siteSettings{}".format(
-            addon_name, addon_version, query
-        ))
+        result = self.get(
+            f"addons/{addon_name}/{addon_version}/siteSettings{query}"
+        )
         result.raise_for_status()
         return result.data
 
@@ -4406,7 +4397,7 @@ class ServerAPI(object):
             secret_name (str): Name of secret to delete.
 
         """
-        response = self.delete("secrets/{}".format(secret_name))
+        response = self.delete(f"secrets/{secret_name}")
         response.raise_for_status()
         return response.data
 
@@ -4429,7 +4420,7 @@ class ServerAPI(object):
         if not project_name:
             return None
 
-        response = self.get("projects/{}".format(project_name))
+        response = self.get(f"projects/{project_name}")
         # TODO ignore only error about not existing project
         if response.status != 200:
             return None
@@ -4560,7 +4551,7 @@ class ServerAPI(object):
             "true" if include_attrib else "false"
         )
         response = self.get(
-            "projects/{}/folders{}".format(project_name, query)
+            f"projects/{project_name}/folders{query}"
         )
         response.raise_for_status()
         return response.data["folders"]
@@ -4612,12 +4603,7 @@ class ServerAPI(object):
 
         if library is not None:
             query_keys["library"] = "true" if library else "false"
-        query = ""
-        if query_keys:
-            query = "?{}".format(",".join([
-                f"{key}={value}"
-                for key, value in query_keys.items()
-            ]))
+        query = prepare_query_string(query_keys)
 
         response = self.get(f"projects{query}", **query_keys)
         response.raise_for_status()
@@ -5203,7 +5189,7 @@ class ServerAPI(object):
                 create_data[key] = value
 
         response = self.post(
-            "projects/{}/folders".format(project_name),
+            f"projects/{project_name}/folders",
             **create_data
         )
         response.raise_for_status()
@@ -5289,7 +5275,7 @@ class ServerAPI(object):
                 folder, products, versions and representations.
 
         """
-        url = "projects/{}/folders/{}".format(project_name, folder_id)
+        url = f"projects/{project_name}/folders/{folder_id}"
         if force:
             url += "?force=true"
         response = self.delete(url)
@@ -5709,7 +5695,7 @@ class ServerAPI(object):
                 create_data[key] = value
 
         response = self.post(
-            "projects/{}/tasks".format(project_name),
+            f"projects/{project_name}/tasks",
             **create_data
         )
         response.raise_for_status()
@@ -5781,7 +5767,7 @@ class ServerAPI(object):
                 update_data[key] = value
 
         response = self.patch(
-            "projects/{}/tasks/{}".format(project_name, task_id),
+            f"projects/{project_name}/tasks/{task_id}",
             **update_data
         )
         response.raise_for_status()
@@ -5795,7 +5781,7 @@ class ServerAPI(object):
 
         """
         response = self.delete(
-            "projects/{}/tasks/{}".format(project_name, task_id)
+            f"projects/{project_name}/tasks/{task_id}"
         )
         response.raise_for_status()
 
@@ -6198,7 +6184,7 @@ class ServerAPI(object):
                 create_data[key] = value
 
         response = self.post(
-            "projects/{}/products".format(project_name),
+            f"projects/{project_name}/products",
             **create_data
         )
         response.raise_for_status()
@@ -6252,7 +6238,7 @@ class ServerAPI(object):
                 update_data[key] = value
 
         response = self.patch(
-            "projects/{}/products/{}".format(project_name, product_id),
+            f"projects/{project_name}/products/{product_id}",
             **update_data
         )
         response.raise_for_status()
@@ -6266,7 +6252,7 @@ class ServerAPI(object):
 
         """
         response = self.delete(
-            "projects/{}/products/{}".format(project_name, product_id)
+            f"projects/{project_name}/products/{product_id}"
         )
         response.raise_for_status()
 
@@ -6808,7 +6794,7 @@ class ServerAPI(object):
                 create_data[key] = value
 
         response = self.post(
-            "projects/{}/versions".format(project_name),
+            f"projects/{project_name}/versions",
             **create_data
         )
         response.raise_for_status()
@@ -7446,7 +7432,7 @@ class ServerAPI(object):
         """
         if not isinstance(context_filters, dict):
             raise TypeError(
-                "Expected 'dict' got {}".format(str(type(context_filters)))
+                f"Expected 'dict' got {str(type(context_filters))}"
             )
 
         filter_body = {}
@@ -7479,7 +7465,7 @@ class ServerAPI(object):
             })
 
         response = self.post(
-            "projects/{}/repreContextFilter".format(project_name),
+            f"projects/{project_name}/repreContextFilter",
             context=body_context_filters,
             **filter_body
         )
@@ -7537,7 +7523,7 @@ class ServerAPI(object):
                 create_data[key] = value
 
         response = self.post(
-            "projects/{}/representations".format(project_name),
+            f"projects/{project_name}/representations",
             **create_data
         )
         response.raise_for_status()
@@ -7592,9 +7578,7 @@ class ServerAPI(object):
                 update_data[key] = value
 
         response = self.patch(
-            "projects/{}/representations/{}".format(
-                project_name, representation_id
-            ),
+            f"projects/{project_name}/representations/{representation_id}",
             **update_data
         )
         response.raise_for_status()
@@ -7610,9 +7594,7 @@ class ServerAPI(object):
 
         """
         response = self.delete(
-            "projects/{}/representation/{}".format(
-                project_name, representation_id
-            )
+            f"projects/{project_name}/representation/{representation_id}"
         )
         response.raise_for_status()
 
@@ -7881,11 +7863,9 @@ class ServerAPI(object):
         ):
             entity_type += "s"
 
-        response = self.raw_get("projects/{}/{}/{}/thumbnail".format(
-            project_name,
-            entity_type,
-            entity_id
-        ))
+        response = self.raw_get(
+            f"projects/{project_name}/{entity_type}/{entity_id}/thumbnail"
+        )
         return self._prepare_thumbnail_content(project_name, response)
 
     def get_folder_thumbnail(
@@ -7993,7 +7973,7 @@ class ServerAPI(object):
 
         mime_type = get_media_mime_type(src_filepath)
         response = self.upload_file(
-            "projects/{}/thumbnails".format(project_name),
+            f"projects/{project_name}/thumbnails",
             src_filepath,
             request_type=RequestTypes.post,
             headers={"Content-Type": mime_type},
@@ -8064,14 +8044,14 @@ class ServerAPI(object):
 
         """
         if self.get_project(project_name):
-            raise ValueError("Project with name \"{}\" already exists".format(
-                project_name
-            ))
+            raise ValueError(
+                f"Project with name \"{project_name}\" already exists"
+            )
 
         if not PROJECT_NAME_REGEX.match(project_name):
-            raise ValueError((
-                "Project name \"{}\" contain invalid characters"
-            ).format(project_name))
+            raise ValueError(
+                f"Project name \"{project_name}\" contain invalid characters"
+            )
 
         preset = self.get_project_anatomy_preset(preset_name)
 
@@ -8084,12 +8064,12 @@ class ServerAPI(object):
         )
 
         if result.status != 201:
-            details = "Unknown details ({})".format(result.status)
+            details = f"Unknown details ({result.status})"
             if result.data:
                 details = result.data.get("detail") or details
-            raise ValueError("Failed to create project \"{}\": {}".format(
-                project_name, details
-            ))
+            raise ValueError(
+                f"Failed to create project \"{project_name}\": {details}"
+            )
 
         return self.get_project(project_name)
 
@@ -8152,7 +8132,7 @@ class ServerAPI(object):
             if value is not None
         })
         response = self.patch(
-            "projects/{}".format(project_name),
+            f"projects/{project_name}",
             **changes
         )
         response.raise_for_status()
@@ -8167,16 +8147,15 @@ class ServerAPI(object):
 
         """
         if not self.get_project(project_name):
-            raise ValueError("Project with name \"{}\" was not found".format(
-                project_name
-            ))
-
-        result = self.delete("projects/{}".format(project_name))
-        if result.status_code != 204:
             raise ValueError(
-                "Failed to delete project \"{}\". {}".format(
-                    project_name, result.data["detail"]
-                )
+                f"Project with name \"{project_name}\" was not found"
+            )
+
+        result = self.delete(f"projects/{project_name}")
+        if result.status_code != 204:
+            detail = result.data["detail"]
+            raise ValueError(
+                f"Failed to delete project \"{project_name}\". {detail}"
             )
 
     # --- Links ---
@@ -8217,7 +8196,7 @@ class ServerAPI(object):
             list[dict[str, Any]]: Link types available on project.
 
         """
-        response = self.get("projects/{}/links/types".format(project_name))
+        response = self.get(f"projects/{project_name}/links/types")
         response.raise_for_status()
         return response.data["types"]
 
@@ -8290,7 +8269,7 @@ class ServerAPI(object):
             link_type_name, input_type, output_type
         )
         response = self.put(
-            "projects/{}/links/types/{}".format(project_name, full_type_name),
+            f"projects/{project_name}/links/types/{full_type_name}",
             **data
         )
         response.raise_for_status()
@@ -8318,7 +8297,8 @@ class ServerAPI(object):
             link_type_name, input_type, output_type
         )
         response = self.delete(
-            "projects/{}/links/types/{}".format(project_name, full_type_name))
+            f"projects/{project_name}/links/types/{full_type_name}"
+        )
         response.raise_for_status()
 
     def make_sure_link_type_exists(
@@ -8402,10 +8382,10 @@ class ServerAPI(object):
         ):
             kwargs["link"] = full_link_type_name
             if link_name:
-                raise UnsupportedServerVersion((
+                raise UnsupportedServerVersion(
                     "Link name is not supported"
-                    " for version of AYON server {}"
-                ).format(self.server_version))
+                    f" for version of AYON server {self.server_version}"
+                )
         else:
             kwargs["linkType"] = full_link_type_name
 
@@ -8413,7 +8393,7 @@ class ServerAPI(object):
             kwargs["name"] = link_name
 
         response = self.post(
-            "projects/{}/links".format(project_name), **kwargs
+            f"projects/{project_name}/links", **kwargs
         )
         response.raise_for_status()
         return response.data
@@ -8430,7 +8410,7 @@ class ServerAPI(object):
 
         """
         response = self.delete(
-            "projects/{}/links/{}".format(project_name, link_id)
+            f"projects/{project_name}/links/{link_id}"
         )
         response.raise_for_status()
 
@@ -8582,7 +8562,7 @@ class ServerAPI(object):
             fields.discard("name")
             link_fields.discard("links")
             link_fields |= {
-                "links.{}".format(field)
+                f"links.{field}"
                 for field in fields
             }
         # ---------
@@ -8973,7 +8953,7 @@ class ServerAPI(object):
         op_results = result.get("operations")
         if op_results is None:
             raise FailedOperations(
-                "Operation failed. Content: {}".format(str(result))
+                f"Operation failed. Content: {str(result)}"
             )
 
         if result.get("success") or not raise_on_fail:
@@ -9008,21 +8988,21 @@ class ServerAPI(object):
             if "folderTypes" in fields:
                 fields.remove("folderTypes")
                 fields |= {
-                    "folderTypes.{}".format(name)
+                    f"folderTypes.{name}"
                     for name in self.get_default_fields_for_type("folderType")
                 }
 
             if "taskTypes" in fields:
                 fields.remove("taskTypes")
                 fields |= {
-                    "taskTypes.{}".format(name)
+                    f"taskTypes.{name}"
                     for name in self.get_default_fields_for_type("taskType")
                 }
 
             if "productTypes" in fields:
                 fields.remove("productTypes")
                 fields |= {
-                    "productTypes.{}".format(name)
+                    f"productTypes.{name}"
                     for name in self.get_default_fields_for_type(
                         "productType"
                     )

--- a/ayon_api/utils.py
+++ b/ayon_api/utils.py
@@ -139,19 +139,29 @@ class ThumbnailContent:
         )
 
 
-def prepare_query_string(key_values: Dict[str, Any]):
+def prepare_query_string(
+    key_values: Dict[str, Any], skip_none: bool = True
+) -> str:
     """Prepare data to query string.
 
     If there are any values a query starting with '?' is returned otherwise
     an empty string.
 
     Args:
-         dict[str, Any]: Query values.
+         key_values (dict[str, Any]): Query values.
+         skip_none (bool): Filter values which are 'None'.
 
     Returns:
         str: Query string.
 
     """
+    if skip_none:
+        key_values = {
+            key: value
+            for key, value in key_values.items()
+            if value is not None
+        }
+
     if not key_values:
         return ""
     return "?{}".format(urlencode(key_values))


### PR DESCRIPTION
## Changelog Description
Use f-string formatting in server api code.

## Additional review information
Also enhanced query preparation, moving most of the "skip keys" logic into `prepare_query_string`.

## Testing notes:
1. Validate the functionality.
2. All functions should still work as expected.
