### PR TITLE
Operations: Better error message

### DIFF
--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -8971,8 +8971,11 @@ class ServerAPI(object):
 
         op_results = result.get("operations")
         if op_results is None:
+            detail = result.get("detail")
+            if detail:
+                raise FailedOperations(f"Operation failed. Detail: {detail}")
             raise FailedOperations(
-                "Operation failed. Content: {}".format(str(result))
+                f"Operation failed. Content: {result.text}"
             )
 
         if result.get("success") or not raise_on_fail:

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -254,6 +254,12 @@ class RestApiResponse(object):
     def status_code(self) -> int:
         return self.status
 
+    @property
+    def ok(self) -> bool:
+        if self._response is not None:
+            return self._response.ok
+        return False
+
     def raise_for_status(self, message=None):
         if self._response is None:
             if self._data and self._data.get("detail"):


### PR DESCRIPTION
## Changelog Description
Add detail to error message if is available and fill content if is not available.

## Additional review information
Currently the error on failed operations does not tell anything usefull when happens. Also added `ok` property to response class, it was not needed at the end in this PR, but I already had it there...

## Testing notes:
1. Failed operations should tell why it crashed.
