### PR TITLE
Add traits to representation fields

### DIFF
--- a/ayon_api/constants.py
+++ b/ayon_api/constants.py
@@ -131,6 +131,7 @@ DEFAULT_REPRESENTATION_FIELDS = {
     "data",
     "status",
     "tags",
+    "traits",
 }
 
 REPRESENTATION_FILES_FIELDS = {


### PR DESCRIPTION
## Changelog Description
This adds support for `traits` field for representation, supported by the server from https://github.com/ynput/ayon-backend/pull/552, https://github.com/ynput/ayon-backend/pull/466 and https://github.com/ynput/ayon-backend/pull/431

## Additional review information
For more information about traits see https://github.com/ynput/ayon-core/issues/909