### PR TITLE
Projects query: Fix active filtering

### DIFF
--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -4646,10 +4646,14 @@ class ServerAPI(object):
             return
 
         self._prepare_fields("project", fields, own_attributes)
+        if active is not None:
+            fields.add("active")
 
         query = projects_graphql_query(fields)
         for parsed_data in query.continuous_query(self):
             for project in parsed_data["projects"]:
+                if active is not None and active is not project["active"]:
+                    continue
                 if own_attributes:
                     fill_own_attribs(project)
                 yield project


### PR DESCRIPTION
## Changelog Description
Function `get_projects` does respect `active` filtering.

## Additional review information
The `active` argument was ignored when project were fetched using GraphQl.

## Testing notes:
1. Make sure you have at least on active and one inactive project in AYON.
2. Run the `get_projects` with different `active` filtering options. `True` only active projects, `False` only inactive, `None` all projects.

Resolves https://github.com/ynput/ayon-python-api/issues/238