### PR TITLE
Chore: Removed appdirs from dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -13,18 +13,6 @@ files = [
 ]
 
 [[package]]
-name = "appdirs"
-version = "1.4.4"
-description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
-optional = false
-python-versions = "*"
-groups = ["main"]
-files = [
-    {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
-    {file = "appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"},
-]
-
-[[package]]
 name = "astroid"
 version = "2.11.7"
 description = "An abstract syntax tree for Python with inference support."
@@ -967,4 +955,4 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=4.6)", "pytest-black (
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.6.5"
-content-hash = "5000b7799750aee6806e100abe2246c1d207b9d4444a1c47ad76d343598e9099"
+content-hash = "0d5fd126843b2155bfd8c4d501d3dd62c874a05457ead367debb1534712e5f40"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ classifiers = [
 dependencies = [
     "requests >= 2.27.1",
     "Unidecode >= 1.3.0",
-    "appdirs >=1, <2",
 ]
 
 [project.urls]
@@ -42,7 +41,6 @@ packages = [
 python = ">=3.6.5"
 requests = "^2.27"
 Unidecode = "^1.3"
-appdirs = "^1.4"
 
 [tool.poetry.group.dev.dependencies]
 sphinx = "*"


### PR DESCRIPTION
## Changelog Description
Removed unused `appdirs` dependency.

## Additional review information
Not sure if it was ever used, but is not used in the codebase at this moment.

## Testing notes:
1. Validate that appdirs is really not used.
