### PR TITLE
Headers: Pass in 'referer' header

### DIFF
--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -1257,6 +1257,7 @@ class ServerAPI(object):
             "Content-Type": content_type,
             "x-ayon-platform": platform.system().lower(),
             "x-ayon-hostname": platform.node(),
+            "referer": self.get_base_url(),
         }
         if self._site_id is not None:
             headers["x-ayon-site-id"] = self._site_id


### PR DESCRIPTION
## Changelog Description
Header `referer` can be used by server to fill in "client's server url".

## Additional review information
That is helpfull for e.g. webactions which need to pass correct server url into the triggered process.

## Testing notes:
Nothing much to validate.
