### PR TITLE
add AYON_CERT_FILE to try server request

### DIFF
--- a/ayon_api/utils.py
+++ b/ayon_api/utils.py
@@ -329,7 +329,9 @@ def _try_connect_to_server(
     try:
         # TODO add validation if the url lead to AYON server
         #   - this won't validate if the url lead to 'google.com'
-        requests.get(url, timeout=timeout, verify=os.getenv("AYON_CERT_FILE"))
+        requests.get(
+            url, timeout=timeout, verify=os.getenv("AYON_CERT_FILE")
+        )
 
     except BaseException:
         return False

--- a/ayon_api/utils.py
+++ b/ayon_api/utils.py
@@ -329,7 +329,7 @@ def _try_connect_to_server(
     try:
         # TODO add validation if the url lead to AYON server
         #   - this won't validate if the url lead to 'google.com'
-        requests.get(url, timeout=timeout)
+        requests.get(url, timeout=timeout, verify=os.getenv("AYON_CERT_FILE"))
 
     except BaseException:
         return False


### PR DESCRIPTION
## Changelog Description
When the Ayon Launcher tests the server url before login, the `AYON_CERT_FILE` env var is not passed to the get requests that pings the server, and fails even if there is a custom self signed cert pointed in that var `AYON_CERT_FILE`.
This PR simply adds that env var to the verify kwarg in the requests.get method.
