### PR TITLE
Utils: Validate url enhancements

### DIFF
--- a/ayon_api/utils.py
+++ b/ayon_api/utils.py
@@ -4,6 +4,7 @@ import datetime
 import uuid
 import string
 import platform
+import traceback
 import collections
 from urllib.parse import urlparse, urlencode
 import typing

--- a/ayon_api/utils.py
+++ b/ayon_api/utils.py
@@ -483,7 +483,12 @@ def is_token_valid(
     return False
 
 
-def validate_url(url: str, timeout: Optional[int] = None) -> str:
+def validate_url(
+    url: str,
+    timeout: Optional[int] = None,
+    verify: Optional["Union[str, bool]"] = None,
+    cert: Optional[str] = None,
+) -> str:
     """Validate url if is valid and server is available.
 
     Validation checks if can be parsed as url and contains scheme.
@@ -540,12 +545,23 @@ def validate_url(url: str, timeout: Optional[int] = None) -> str:
     # Try add 'https://' scheme if is missing
     # - this will trigger UrlError if both will crash
     if not parsed_url.scheme:
-        new_url = "https://" + modified_url
-        if _try_connect_to_server(new_url, timeout=timeout):
+        new_url = _try_connect_to_server(
+            "http://" + modified_url,
+            timeout=timeout,
+            verify=verify,
+            cert=cert,
+        )
+        if new_url:
             return new_url
 
-    if _try_connect_to_server(modified_url, timeout=timeout):
-        return modified_url
+    new_url = _try_connect_to_server(
+        modified_url,
+        timeout=timeout,
+        verify=verify,
+        cert=cert,
+    )
+    if new_url:
+        return new_url
 
     hints = []
     if "/" in parsed_url.path or not parsed_url.scheme:


### PR DESCRIPTION
## Changelog Description
Validate url does handle scheme update (`http` -> `https`), and uses same verify and cert values as `ServerAPI` does.

## Additional review information
Not sure how to test cert and verify? If `validate_url` is used on ssl secured address, the output url should be always `https`.

## Testing notes:
1. Pass `http://some.secure.ayon` into the function.
2. Output should be `https://some.secure.ayon`.
