### PR TITLE
Chore: Uunidecode machine name for header value

### DIFF
--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -96,6 +96,7 @@ from .utils import (
     NOT_SET,
     get_media_mime_type,
     SortOrder,
+    get_machine_name,
 )
 
 if typing.TYPE_CHECKING:
@@ -1256,7 +1257,7 @@ class ServerAPI(object):
         headers = {
             "Content-Type": content_type,
             "x-ayon-platform": platform.system().lower(),
-            "x-ayon-hostname": platform.node(),
+            "x-ayon-hostname": get_machine_name(),
             "referer": self.get_base_url(),
         }
         if self._site_id is not None:

--- a/ayon_api/utils.py
+++ b/ayon_api/utils.py
@@ -89,6 +89,17 @@ def get_default_settings_variant() -> str:
     return os.environ.get(DEFAULT_VARIANT_ENV_KEY) or "production"
 
 
+def get_machine_name() -> str:
+    """Get machine name.
+
+    Returns:
+        str: Machine name.
+
+    """
+    return platform.node()
+    return unidecode.unidecode(platform.node())
+
+
 def get_default_site_id() -> Optional[str]:
     """Site id used for server connection.
 


### PR DESCRIPTION
## Changelog Description
Machine name passed to headers is unidecoded as unicode characters can't be used for header value.

## Testing notes:
1. Chance machine name to contain unicode characters not available in ASCII (`ěščřžýáíé`).
2. Try to create connection using ayon api.
3. It should not fail.

Resolves https://github.com/ynput/ayon-python-api/issues/230