### PR TITLE
User: Data conversion

### DIFF
--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -1187,8 +1187,9 @@ class ServerAPI(object):
 
         for parsed_data in query.continuous_query(self):
             for user in parsed_data["users"]:
-                user["accessGroups"] = json.loads(
-                    user["accessGroups"])
+                access_groups = user.get("accessGroups")
+                if isinstance(access_groups, str):
+                    user["accessGroups"] = json.loads(access_groups)
                 yield user
 
     def get_user_by_name(

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -1250,7 +1250,9 @@ class ServerAPI(object):
 
         response = self.get(f"users/{username}")
         response.raise_for_status()
-        return response.data
+        user = response.data
+        fill_own_attribs(user)
+        return user
 
     def get_headers(
         self, content_type: Optional[str] = None

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -1190,6 +1190,10 @@ class ServerAPI(object):
                 access_groups = user.get("accessGroups")
                 if isinstance(access_groups, str):
                     user["accessGroups"] = json.loads(access_groups)
+                all_attrib = user.get("allAttrib")
+                if isinstance(all_attrib, str):
+                    user["allAttrib"] = json.loads(all_attrib)
+                fill_own_attribs(user)
                 yield user
 
     def get_user_by_name(


### PR DESCRIPTION
## Changelog Description
Convert parse json string values and convert ownAttrib on user to same structure as on other entities.

## Testing notes:
1. Function `get_users` does not require `accessGroups` in `fields` if are customized.
2. Values of `accessGroups` and `allAttrib` are converted from json string to python object when received using `get_users`.
3. Function `get_user` does fill `ownAttrib` the same way as other entities (making it a dictionary with `None` values for those which don't have own values on user).
