### PR TITLE
Chore: Fix PEP 625 for PyPi

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -6,7 +6,7 @@
 # separate terms of service, privacy policy, and support
 # documentation.
 
-name: Upload Python Package
+name: ⬆️ Upload Python Package
 
 on:
   release:
@@ -17,8 +17,10 @@ permissions:
 
 jobs:
   deploy:
-
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/ayon-python-api
 
     steps:
     - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "ayon_api"
+name = "ayon-python-api"
 version = "1.1.4-dev"
 description = "AYON Python API"
 license = {file = "LICENSE"}
@@ -27,7 +27,7 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-name = "ayon_api"
+name = "ayon-python-api"
 version = "1.1.4-dev"
 description = "AYON Python API"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "ayon-python-api"
+name = "ayon_api"
 version = "1.1.4-dev"
 description = "AYON Python API"
 license = {file = "LICENSE"}
@@ -27,7 +27,7 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-name = "ayon-python-api"
+name = "ayon_api"
 version = "1.1.4-dev"
 description = "AYON Python API"
 authors = [

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ _version_content = {}
 exec(open(VERSION_PATH).read(), _version_content)
 
 setup(
-    name="ayon-python-api",
+    name="ayon_api",
     version=_version_content["__version__"],
     py_modules=["ayon_api"],
     packages=["ayon_api"],


### PR DESCRIPTION
## Changelog Description
Package created using setup.py is named `ayon_api` instead of `ayon-python-api`.

## Additional review information
Added more data to the action with url to PyPi and added icon to action title.

## Testing notes:
1. New release should not cause PEP 625 error.