### PR TITLE
Project fetching updates

### DIFF
--- a/ayon_api/_api.py
+++ b/ayon_api/_api.py
@@ -4481,12 +4481,12 @@ def get_project_product_types(
     project_name: str,
     fields: Optional[Iterable[str]] = None,
 ) -> List["ProductTypeDict"]:
-    """Types of products available on a project.
+    """DEPRECATED Types of products available in a project.
 
-    Filter only product types available on project.
+    Filter only product types available in a project.
 
     Args:
-        project_name (str): Name of project where to look for
+        project_name (str): Name of the project where to look for
             product types.
         fields (Optional[Iterable[str]]): Product types fields to query.
 
@@ -4505,7 +4505,7 @@ def get_product_type_names(
     project_name: Optional[str] = None,
     product_ids: Optional[Iterable[str]] = None,
 ) -> Set[str]:
-    """Product type names.
+    """DEPRECATED Product type names.
 
     Warnings:
         This function will be probably removed. Matters if 'products_id'

--- a/ayon_api/constants.py
+++ b/ayon_api/constants.py
@@ -51,6 +51,7 @@ DEFAULT_PRODUCT_TYPE_FIELDS = {
 # --- Project ---
 DEFAULT_PROJECT_FIELDS = {
     "active",
+    "library",
     "name",
     "code",
     "config",

--- a/ayon_api/constants.py
+++ b/ayon_api/constants.py
@@ -30,15 +30,41 @@ DEFAULT_USER_FIELDS = {
     "attrib.fullName",
 }
 
-# --- Folder types ---
+# --- Project folder types ---
 DEFAULT_FOLDER_TYPE_FIELDS = {
     "name",
     "icon",
 }
 
-# --- Task types ---
+# --- Project task types ---
 DEFAULT_TASK_TYPE_FIELDS = {
     "name",
+}
+
+# --- Project tags ---
+DEFAULT_PROJECT_TAGS_FIELDS = {
+    "name",
+    "color",
+}
+
+# --- Project statuses ---
+DEFAULT_PROJECT_STATUSES_FIELDS = {
+    "color",
+    "icon",
+    "name",
+    "scope",
+    "shortName",
+    "state",
+}
+
+# --- Project link types ---
+DEFAULT_PROJECT_LINK_TYPES_FIELDS = {
+    "color",
+    "inputType",
+    "linkType",
+    "name",
+    "outputType",
+    "style",
 }
 
 # --- Product types ---

--- a/ayon_api/constants.py
+++ b/ayon_api/constants.py
@@ -56,10 +56,14 @@ DEFAULT_PROJECT_FIELDS = {
     "code",
     "config",
     "createdAt",
+    "updatedAt",
     "data",
     "folderTypes",
     "taskTypes",
-    "productTypes",
+    "linkTypes",
+    "statuses",
+    "tags",
+    "attrib",
 }
 
 # --- Folders ---

--- a/ayon_api/graphql_queries.py
+++ b/ayon_api/graphql_queries.py
@@ -77,7 +77,9 @@ def project_graphql_query(fields):
 
 def projects_graphql_query(fields):
     query = GraphQlQuery("ProjectsQuery")
+    project_name_var = query.add_variable("projectName", "String!")
     projects_field = query.add_field_with_edges("projects")
+    projects_field.set_filter("name", project_name_var)
 
     nested_fields = fields_to_dict(fields)
 

--- a/ayon_api/graphql_queries.py
+++ b/ayon_api/graphql_queries.py
@@ -121,30 +121,6 @@ def product_types_query(fields):
     return query
 
 
-def project_product_types_query(fields):
-    query = GraphQlQuery("ProjectProductTypes")
-    project_query = query.add_field("project")
-    project_name_var = query.add_variable("projectName", "String!")
-    project_query.set_filter("name", project_name_var)
-    product_types_field = project_query.add_field("productTypes")
-    nested_fields = fields_to_dict(fields)
-
-    query_queue = collections.deque()
-    for key, value in nested_fields.items():
-        query_queue.append((key, value, product_types_field))
-
-    while query_queue:
-        item = query_queue.popleft()
-        key, value, parent = item
-        field = parent.add_field(key)
-        if value is FIELD_VALUE:
-            continue
-
-        for k, v in value.items():
-            query_queue.append((k, v, field))
-    return query
-
-
 def folders_graphql_query(fields):
     query = GraphQlQuery("FoldersQuery")
     project_name_var = query.add_variable("projectName", "String!")

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -60,7 +60,6 @@ from .graphql import GraphQlQuery, INTROSPECTION_QUERY
 from .graphql_queries import (
     project_graphql_query,
     projects_graphql_query,
-    project_product_types_query,
     product_types_query,
     folders_graphql_query,
     tasks_graphql_query,
@@ -6121,12 +6120,12 @@ class ServerAPI(object):
     def get_project_product_types(
         self, project_name: str, fields: Optional[Iterable[str]] = None
     ) -> List["ProductTypeDict"]:
-        """Types of products available on a project.
+        """DEPRECATED Types of products available in a project.
 
-        Filter only product types available on project.
+        Filter only product types available in a project.
 
         Args:
-            project_name (str): Name of project where to look for
+            project_name (str): Name of the project where to look for
                 product types.
             fields (Optional[Iterable[str]]): Product types fields to query.
 
@@ -6134,15 +6133,22 @@ class ServerAPI(object):
             List[ProductTypeDict]: Product types information.
 
         """
-        if not fields:
-            fields = self.get_default_fields_for_type("productType")
+        warnings.warn(
+            "Used deprecated function 'get_project_product_types'."
+            " Use 'get_project' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if fields is None:
+            fields = {"productTypes"}
+        else:
+            fields = {
+                f"productTypes.{key}"
+                for key in fields
+            }
 
-        query = project_product_types_query(fields)
-        query.set_variable_value("projectName", project_name)
-
-        parsed_data = query.query(self)
-
-        return parsed_data.get("project", {}).get("productTypes", [])
+        project = self.get_project(project_name, fields=fields)
+        return project["productTypes"]
 
     def get_product_type_names(
         self,

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -6095,7 +6095,7 @@ class ServerAPI(object):
         """
         warnings.warn(
             "Used deprecated function 'get_project_product_types'."
-            " Use 'get_project' instead.",
+            " Use 'get_project' with 'productTypes' in 'fields' instead.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -25,6 +25,7 @@ except ImportError:
     HTTPStatus = None
 
 import requests
+
 try:
     # This should be used if 'requests' have it available
     from requests.exceptions import JSONDecodeError as RequestsJSONDecodeError
@@ -1588,7 +1589,6 @@ class ServerAPI(object):
             )
             statuses = states
 
-
         filters = {}
         if not _prepare_list_filters(
             filters,
@@ -1768,7 +1768,6 @@ class ServerAPI(object):
         response = self.delete(f"events/{event_id}")
         response.raise_for_status()
         return response
-
 
     def enroll_event_job(
         self,
@@ -9078,7 +9077,7 @@ class ServerAPI(object):
             if (maj_v, min_v, patch_v) > (1, 10, 0):
                 task_types_fields |= {"color", "icon", "shortName"}
             fields |= {f"taskTypes.{name}" for name in task_types_fields}
-        
+
         if "statuses" in fields:
             fields.remove("statuses")
             statuses_fields = set()

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -2732,6 +2732,9 @@ class ServerAPI(object):
 
         if entity_type == "project":
             entity_type_defaults = set(DEFAULT_PROJECT_FIELDS)
+            maj_v, min_v, patch_v, _, _ = self.server_version_tuple
+            if (maj_v, min_v, patch_v) > (1, 10, 0):
+                entity_type_defaults.add("productTypes")
 
         elif entity_type == "folder":
             entity_type_defaults = set(DEFAULT_FOLDER_FIELDS)

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -1108,7 +1108,6 @@ class ServerAPI(object):
             )
         return self._graphql_allows_traits_in_representations
 
-
     def _get_user_info(self) -> Optional[Dict[str, Any]]:
         if self._access_token is None:
             return None

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -4419,7 +4419,6 @@ class ServerAPI(object):
         for project_name in self.get_project_names(active, library):
             project = self.get_rest_project(project_name)
             if project:
-                self._fill_project_entity_data(project)
                 yield project
 
     def get_rest_entity_by_id(
@@ -4609,23 +4608,23 @@ class ServerAPI(object):
             )
             return
 
-        p_by_name = {}
         if use_graphql:
-            p_by_name = {
-                p["name"]: p
-                for p in self._get_graphql_projects(
-                    active,
-                    library,
-                    fields={"name", "productTypes"},
-                    own_attributes=own_attributes,
-                )
-            }
+            for graphql_project in self._get_graphql_projects(
+                active,
+                library,
+                fields={"name", "productTypes"},
+                own_attributes=own_attributes,
+            ):
+                project = self.get_project(graphql_project["name"])
+                if own_attributes:
+                    fill_own_attribs(project)
+                project["productTypes"] = graphql_project["productTypes"]
+                yield project
+            return
+
         for project in self.get_rest_projects(active, library):
             if own_attributes:
                 fill_own_attribs(project)
-            graphql_p = p_by_name.get(project["name"])
-            if graphql_p:
-                project["productTypes"] = graphql_p["productTypes"]
             yield project
 
     def get_project(

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -6049,7 +6049,9 @@ class ServerAPI(object):
             set[str]: Product type names.
 
         """
-        if project_name and product_ids:
+        if project_name:
+            if not product_ids:
+                return set()
             products = self.get_products(
                 project_name,
                 product_ids=product_ids,
@@ -6063,9 +6065,7 @@ class ServerAPI(object):
 
         return {
             product_info["name"]
-            for product_info in self.get_project_product_types(
-                project_name, fields=["name"]
-            )
+            for product_info in self.get_product_types(project_name)
         }
 
     def create_product(

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -4598,10 +4598,37 @@ class ServerAPI(object):
             bool: REST endpoint must be used to get requested fields.
 
         """
-        if fields is None:
-            return True
+        maj_v, min_v, patch_v, _, _ = self.server_version_tuple
+        # Up to 1.10.0 some project data were not available in GraphQl.
+        # - 'config', 'tags', 'linkTypes' and 'statuses' at all
+        # - 'taskTypes', 'folderTypes' with only limited data
+        if (maj_v, min_v, patch_v) > (1, 10, 0):
+            return False
+
         for field in fields:
-            if field.startswith("config"):
+            if (
+                field.startswith("config")
+                or field.startswith("folderTypes")
+                or field.startswith("taskTypes")
+                or field.startswith("linkTypes")
+                or field.startswith("statuses")
+                or field.startswith("tags")
+            ):
+                return True
+        return False
+
+    def _should_use_graphql_project(
+        self, fields: Optional[Iterable[str]] = None
+    ) -> bool:
+        """Fetch of project must be done using REST endpoint.
+
+        Returns:
+            bool: REST endpoint must be used to get requested fields.
+
+        """
+        for field in fields:
+            # Product types are available only in GraphQl
+            if field.startswith("productTypes"):
                 return True
         return False
 

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -41,7 +41,6 @@ from .constants import (
     SERVER_RETRIES_ENV_KEY,
     DEFAULT_FOLDER_TYPE_FIELDS,
     DEFAULT_TASK_TYPE_FIELDS,
-    DEFAULT_PROJECT_LINK_TYPES_FIELDS,
     DEFAULT_PROJECT_STATUSES_FIELDS,
     DEFAULT_PROJECT_TAGS_FIELDS,
     DEFAULT_PRODUCT_TYPE_FIELDS,
@@ -59,7 +58,6 @@ from .constants import (
 )
 from .graphql import GraphQlQuery, INTROSPECTION_QUERY
 from .graphql_queries import (
-    project_graphql_query,
     projects_graphql_query,
     product_types_query,
     folders_graphql_query,

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -6033,7 +6033,7 @@ class ServerAPI(object):
         project_name: Optional[str] = None,
         product_ids: Optional[Iterable[str]] = None,
     ) -> Set[str]:
-        """Product type names.
+        """DEPRECATED Product type names.
 
         Warnings:
             This function will be probably removed. Matters if 'products_id'
@@ -6049,6 +6049,12 @@ class ServerAPI(object):
             set[str]: Product type names.
 
         """
+        warnings.warn(
+            "Used deprecated function 'get_product_type_names'."
+            " Use 'get_product_types' or 'get_products' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if project_name:
             if not product_ids:
                 return set()

--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -9024,10 +9024,10 @@ class ServerAPI(object):
             fields.remove("bundle")
             fields.add("data")
 
+        maj_v, min_v, patch_v, _, _ = self.server_version_tuple
         if "folderTypes" in fields:
             fields.remove("folderTypes")
             folder_types_fields = set(DEFAULT_FOLDER_TYPE_FIELDS)
-            maj_v, min_v, patch_v, _, _ = self.server_version_tuple
             if (maj_v, min_v, patch_v) > (1, 10, 0):
                 folder_types_fields |= {"shortName"}
             fields |= {f"folderTypes.{name}" for name in folder_types_fields}
@@ -9035,34 +9035,20 @@ class ServerAPI(object):
         if "taskTypes" in fields:
             fields.remove("taskTypes")
             task_types_fields = set(DEFAULT_TASK_TYPE_FIELDS)
-            maj_v, min_v, patch_v, _, _ = self.server_version_tuple
             if (maj_v, min_v, patch_v) > (1, 10, 0):
                 task_types_fields |= {"color", "icon", "shortName"}
             fields |= {f"taskTypes.{name}" for name in task_types_fields}
 
-        if "statuses" in fields:
-            fields.remove("statuses")
-            statuses_fields = set()
-            maj_v, min_v, patch_v, _, _ = self.server_version_tuple
-            if (maj_v, min_v, patch_v) > (1, 10, 0):
-                statuses_fields = set(DEFAULT_PROJECT_STATUSES_FIELDS)
-            fields |= {f"statuses.{name}" for name in statuses_fields}
-
-        if "tags" in fields:
-            fields.remove("tags")
-            tags_fields = set()
-            maj_v, min_v, patch_v, _, _ = self.server_version_tuple
-            if (maj_v, min_v, patch_v) > (1, 10, 0):
-                tags_fields = set(DEFAULT_PROJECT_TAGS_FIELDS)
-            fields |= {f"tags.{name}" for name in tags_fields}
-
-        if "linkTypes" in fields:
-            fields.remove("linkTypes")
-            link_types_fields = set()
-            maj_v, min_v, patch_v, _, _ = self.server_version_tuple
-            if (maj_v, min_v, patch_v) > (1, 10, 0):
-                link_types_fields = set(DEFAULT_PROJECT_LINK_TYPES_FIELDS)
-            fields |= {f"linkTypes.{name}" for name in link_types_fields}
+        for field, default_fields in (
+            ("statuses", DEFAULT_PROJECT_STATUSES_FIELDS),
+            ("tags", DEFAULT_PROJECT_TAGS_FIELDS),
+            ("linkTypes", DEFAULT_PROJECT_TAGS_FIELDS),
+        ):
+            if (maj_v, min_v, patch_v) <= (1, 10, 0):
+                break
+            if field in fields:
+                fields.remove(field)
+                fields |= {f"{field}.{name}" for name in default_fields}
 
         if "productTypes" in fields:
             fields.remove("productTypes")


### PR DESCRIPTION
## Changelog Description
Functions `get_project` and `get_projects` now do support to get 'productTypes' with other fields.

## Additional review information
If `productTypes` are requested in fields then API uses GraphQl to get list of projects instead of projects endpoint.

Because data from graphql and REST are not 1:1 matching it was necessary to implement some conversion of the data to keep unified structure (e.g. 'bundle').

## Testing notes:
1. Function `get_project_product_types` still works and returns product types used on project.
2. Using `get_project` and `get_projects` with `{"productTypes"}` in fields does return the projects with productTypes.
