### PR TITLE
Chore: Change project name to 'ayon_python_api'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "ayon-python-api"
+name = "ayon_python_api"
 version = "1.2.2-dev"
 description = "AYON Python API"
 license = {file = "LICENSE"}
@@ -27,7 +27,7 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-name = "ayon-python-api"
+name = "ayon_python_api"
 version = "1.2.2-dev"
 description = "AYON Python API"
 authors = [

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ _version_content = {}
 exec(open(VERSION_PATH).read(), _version_content)
 
 setup(
-    name="ayon_api",
+    name="ayon_python_api",
     version=_version_content["__version__"],
     py_modules=["ayon_api"],
     packages=["ayon_api", "ayon_api._api_helpers"],


### PR DESCRIPTION
## Changelog Description
Change project name to `ayon_python_api` which is sanitized name according to PEP 625.

## Additional review information
This should fix issue related to PEP 625.

## Testing notes:
Validation of this will happen on next release.
