### PR TITLE
Server info does respect ssl certificate

### DIFF
--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -1489,6 +1489,8 @@ class ServerAPI(
         response = self.raw_get(
             "info",
             handle_invalid_token=False,
+            verify=self.ssl_verify,
+            cert=self.cert
         )
         response.raise_for_status()
         return response.data


### PR DESCRIPTION
## Changelog Description
Function `_get_server_info` does respect ssl certificate.

## Testing notes:
When hosting the server on https, this code should works without issues. 
```python
import os
os.environ["AYON_SERVER_URL"] = "https://localhost:5000"
os.environ["AYON_API_KEY"] = "veryinsecurapikey"
os.environ["AYON_CA_FILE"]= "E:/Ynput/extras/caddy-root.crt"

import ayon_api
con = ayon_api.get_server_api_connection()

ayon_api.close_connection()
```
Resolves https://github.com/ynput/ayon-python-api/issues/349