### PR TITLE
Fix successful request retry returning previous failure

### DIFF
--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -1560,6 +1560,9 @@ class ServerAPI(
         response = None
         new_response = None
         for retry_idx in reversed(range(max_retries)):
+            # Reset failure of previous attempt, otherwise a successful
+            #   retry would return the previous failure
+            new_response = None
             try:
                 response = function(url, **kwargs)
 

--- a/tests/fake_transfer.py
+++ b/tests/fake_transfer.py
@@ -1,0 +1,41 @@
+"""Helpers to test requests and file transfers without AYON server."""
+import requests
+from requests.structures import CaseInsensitiveDict
+
+
+class FakeResponse:
+    """Minimal stand-in for 'requests.Response'."""
+    def __init__(
+        self, status_code=200, content=b"", headers=None, json_data=None
+    ):
+        self.status_code = status_code
+        self.content = content
+        self.headers = CaseInsensitiveDict(headers or {})
+        self._json_data = json_data
+        self.reason = "Reason"
+        self.text = content.decode(errors="ignore")
+
+    @property
+    def ok(self):
+        return self.status_code < 400
+
+    def raise_for_status(self):
+        if not self.ok:
+            raise requests.exceptions.HTTPError(
+                f"{self.status_code} Error", response=self
+            )
+
+    def json(self):
+        if self._json_data is None:
+            raise ValueError("No json")
+        return self._json_data
+
+    def iter_content(self, chunk_size=1):
+        for idx in range(0, len(self.content), chunk_size):
+            yield self.content[idx:idx + chunk_size]
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False

--- a/tests/test_request_retries.py
+++ b/tests/test_request_retries.py
@@ -1,0 +1,33 @@
+"""Retries of REST requests. Does not require running AYON server."""
+import pytest
+import requests
+
+from ayon_api.server_api import ServerAPI
+
+from .fake_transfer import FakeResponse
+
+
+@pytest.fixture
+def con(monkeypatch):
+    monkeypatch.setattr("time.sleep", lambda *args, **kwargs: None)
+    return ServerAPI("http://localhost:0", create_session=False, max_retries=3)
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [requests.exceptions.ConnectionError("down"), FakeResponse(503)],
+)
+def test_successful_retry_returns_successful_response(con, failure):
+    responses = [failure, FakeResponse(200, json_data={"ok": True})]
+
+    def request_func(url, **kwargs):
+        item = responses.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    response = con._do_rest_request(
+        request_func, "http://localhost:0/api/x", handle_invalid_token=False
+    )
+    assert response.status_code == 200
+    assert response.data == {"ok": True}


### PR DESCRIPTION
## Bug
Retries of REST requests can't succeed. If an attempt fails (connection error, timeout, `502`, `503`) and a later retry succeeds, `_do_rest_request` still returns the **first failure**.

This affects every `get`/`post`/`put`/... call and GraphQl queries, e.g. while the server is restarting or behind a flaky proxy.

## Cause
The failure of an attempt is stored in `new_response`. It was never cleared, and after the retry loop:
```python
if new_response is not None:
    return new_response
```
so the successful `response` from a later attempt was ignored.

## Fix
Reset `new_response = None` at the start of each attempt, so only a failure of the last attempt is returned.

## Reproduce
Needs an attempt to fail and the next one to succeed, so the easiest way is with a patched request function:
```python
import requests
import ayon_api

con = ayon_api.get_server_api_connection()
orig_get = con._session_functions_mapping[ayon_api.utils.RequestTypes.get]
calls = []

def flaky_get(url, **kwargs):
    calls.append(url)
    if len(calls) == 1:
        raise requests.exceptions.ConnectionError("simulated")
    return orig_get(url, **kwargs)

con._session_functions_mapping[ayon_api.utils.RequestTypes.get] = flaky_get
response = con.get("projects")
print(len(calls), response.status_code)
# develop: 2 500   (second attempt succeeded, first failure returned)
# this PR: 2 200
```

## Testing notes
- `tests/test_request_retries.py` covers a connection error and a `503` followed by success.
- Manual: restart the server while a script polls `con.get("info")`; requests that succeed on a retry now return data instead of an error.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
