### PR TITLE
Fix 'max_retries' request argument crashing the request

### DIFF
--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -1521,7 +1521,10 @@ class ServerAPI(
         **kwargs
     ) -> RestApiResponse:
         kwargs.setdefault("timeout", self.timeout)
-        max_retries = kwargs.get("max_retries", self.max_retries)
+        # 'max_retries' must not be passed to request function
+        max_retries = kwargs.pop("max_retries", None)
+        if max_retries is None:
+            max_retries = self.max_retries
         if max_retries < 1:
             max_retries = 1
 

--- a/tests/test_request_max_retries_kwarg.py
+++ b/tests/test_request_max_retries_kwarg.py
@@ -1,0 +1,26 @@
+"""'max_retries' request argument. Does not require running AYON server."""
+import requests
+
+from ayon_api.server_api import ServerAPI
+
+
+def test_max_retries_kwarg_is_not_passed_to_request(monkeypatch):
+    monkeypatch.setattr("time.sleep", lambda *args, **kwargs: None)
+    con = ServerAPI("http://localhost:0", create_session=False, max_retries=5)
+    calls = []
+
+    def request_func(url, **kwargs):
+        # Real request functions raise TypeError on unknown arguments
+        if "max_retries" in kwargs:
+            raise TypeError("unexpected keyword argument 'max_retries'")
+        calls.append(kwargs)
+        raise requests.exceptions.ConnectionError("down")
+
+    response = con._do_rest_request(
+        request_func,
+        "http://localhost:0/api/x",
+        handle_invalid_token=False,
+        max_retries=2,
+    )
+    assert len(calls) == 2
+    assert response.status_code == 500


### PR DESCRIPTION
## Bug
Passing `max_retries` to a raw request crashes:
```
>>> con.raw_get("projects", max_retries=2)
TypeError: Session.request() got an unexpected keyword argument 'max_retries'
```

## Cause
`_do_rest_request` reads the per-request override with `kwargs.get("max_retries", ...)` but leaves it in `kwargs`, which are then passed to `requests` / `requests.Session` functions that don't accept it.

## Fix
`kwargs.pop("max_retries", None)` and fall back to the connection's `max_retries`.

## Reproduce
```python
import ayon_api
con = ayon_api.get_server_api_connection()
print(con.raw_get("projects", max_retries=2).status)
# develop: TypeError
# this PR: 200
```

## Testing notes
- Run the snippet above, with and without a session (`ServerAPI(..., create_session=False)` uses `requests.get` directly — same error on develop).
- `tests/test_request_max_retries_kwarg.py` checks the argument is not passed and the given number of attempts is used.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
