### PR TITLE
Fix corrupted or incomplete files after interrupted download

### DIFF
--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -1686,19 +1686,41 @@ class ServerAPI(
                             progress.set_destination_url(url)
                             continue
                     response.raise_for_status()
-                    if progress.get_content_size() is None:
+                    if offset > 0 and response.status_code != 206:
+                        # Server ignored 'Range' and sends whole file again,
+                        #   already downloaded content must be discarded
+                        stream.seek(0)
+                        stream.truncate()
+                        progress.reset_transferred()
+
+                    content_length = response.headers.get("Content-Length")
+                    if (
+                        progress.get_content_size() is None
+                        and content_length is not None
+                    ):
                         progress.set_content_size(
-                            response.headers["Content-length"]
+                            int(content_length)
+                            + progress.get_transferred_size()
                         )
 
                     for chunk in response.iter_content(chunk_size=chunk_size):
                         stream.write(chunk)
                         progress.add_transferred_chunk(len(chunk))
+
+                content_size = progress.get_content_size()
+                transferred = progress.get_transferred_size()
+                if content_size is not None and transferred != content_size:
+                    # Connection was closed before all content was received
+                    raise requests.exceptions.ConnectionError(
+                        f"Downloaded {transferred} out of {content_size}"
+                        f" bytes from '{url}'."
+                    )
                 break
 
             except (
                 requests.exceptions.Timeout,
                 requests.exceptions.ConnectionError,
+                requests.exceptions.ChunkedEncodingError,
             ):
                 if attempt == retries - 1:
                     raise

--- a/tests/test_download_resume.py
+++ b/tests/test_download_resume.py
@@ -1,0 +1,60 @@
+"""Interrupted downloads. Does not require running AYON server."""
+import io
+
+import pytest
+
+from ayon_api.server_api import ServerAPI
+from ayon_api.utils import RequestTypes
+
+from .fake_transfer import FakeResponse
+
+CONTENT = b"0123456789"
+SIZE_HEADER = {"Content-Length": str(len(CONTENT))}
+
+
+@pytest.fixture
+def con(monkeypatch):
+    monkeypatch.setattr("time.sleep", lambda *args, **kwargs: None)
+    return ServerAPI("http://localhost:0", create_session=False, max_retries=3)
+
+
+def _download(con, get_func):
+    con._base_functions_mapping[RequestTypes.get] = get_func
+    stream = io.BytesIO()
+    progress = con.download_file_to_stream("api/file", stream)
+    return stream.getvalue(), progress
+
+
+def test_incomplete_download_is_continued(con):
+    def get_func(url, **kwargs):
+        if "Range" not in kwargs["headers"]:
+            # Connection closed after 4 bytes without an exception
+            return FakeResponse(200, CONTENT[:4], SIZE_HEADER)
+        assert kwargs["headers"]["Range"] == "bytes=4-"
+        return FakeResponse(206, CONTENT[4:], {"Content-Length": "6"})
+
+    content, progress = _download(con, get_func)
+    assert content == CONTENT
+    assert progress.transferred_size == len(CONTENT)
+
+
+def test_resume_without_range_support_does_not_duplicate(con):
+    calls = []
+
+    def get_func(url, **kwargs):
+        calls.append(url)
+        if len(calls) == 1:
+            return FakeResponse(200, CONTENT[:4], SIZE_HEADER)
+        # Server ignores 'Range' header and sends whole file again
+        return FakeResponse(200, CONTENT, SIZE_HEADER)
+
+    content, progress = _download(con, get_func)
+    assert content == CONTENT
+    assert progress.transferred_size == len(CONTENT)
+
+
+def test_download_without_content_length(con):
+    content, _ = _download(
+        con, lambda url, **kwargs: FakeResponse(200, CONTENT)
+    )
+    assert content == CONTENT


### PR DESCRIPTION
> Stacked on https://github.com/ynput/ayon-python-api/pull/358 (same download/upload loop). Review only the last commit; the base changes to `develop` once that PR is merged.

## Bug
When a download is interrupted and retried, the resulting file can be corrupted or incomplete without any error:

1. **Duplicated content** — the retry sends `Range: bytes=<offset>-`. If the server (or a proxy) ignores `Range` and answers `200` with the whole file, the whole file is appended after the already written part.
2. **Incomplete file accepted** — if the connection is closed before all content arrives without raising (or raises `ChunkedEncodingError`, which wasn't caught), the download is reported as finished.
3. `Content-Length` was stored in progress as a **string**, and a response without it (chunked transfer) raised `KeyError`.

## Cause
- Response status was never checked for `206 Partial Content` before appending.
- Received bytes were never compared with the expected size.
- `response.headers["Content-length"]` was passed directly to `set_content_size`.

## Fix
- If continuing (`offset > 0`) and the response is not `206`, truncate the output stream and reset progress, then write the full content.
- After the response is consumed, compare transferred bytes with the content size. A mismatch raises `ConnectionError`, which is retried with `Range` like other connection errors. `ChunkedEncodingError` is retried as well.
- `Content-Length` is converted to `int` (for `206` the already downloaded offset is added) and a missing header is allowed.

## Reproduce
Hard to trigger on demand against a real server, `tests/test_download_resume.py` simulates:
- a response closed after 4 of 10 bytes, continued with a `206`,
- a server ignoring `Range` (develop result: `b"01230123456789"`),
- a response without `Content-Length` (develop: `KeyError`).

## Testing notes
- Normal downloads: `con.download_file(...)` of a thumbnail/file gives identical bytes and `progress.content_size` is now an `int`.
- Manual interruption: download a large file through a proxy that drops the connection (e.g. [toxiproxy](https://github.com/Shopify/toxiproxy) `limit_data` toxic), compare the checksum with the source file. Test once with a proxy that strips `Range` to cover the `200` case.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
