### PR TITLE
Fix 'api/' endpoint auto-fix of file transfers

### DIFF
--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -1662,7 +1662,9 @@ class ServerAPI(
 
         retries = max(self.max_retries, 1)
         api_prepended = False
-        for attempt in range(retries):
+        attempt = 0
+        while True:
+            attempt += 1
             # Continue in download
             offset = progress.get_transferred_size()
             if offset > 0:
@@ -1671,20 +1673,29 @@ class ServerAPI(
             try:
                 with get_func(url, **kwargs) as response:
                     # Auto-fix missing 'api/'
+                    # NOTE Web frontend returns 'index.html' with status 200
+                    #   for unknown urls, which is not a file to download.
+                    is_frontend_page = (
+                        response.ok
+                        and "text/html" in response.headers.get(
+                            "Content-Type", ""
+                        )
+                    )
                     if (
-                        response.status_code in (404, 405)
+                        (
+                            response.status_code in (404, 405)
+                            or is_frontend_page
+                        )
                         and not api_prepended
+                        and not endpoint.startswith(self._base_url)
+                        and not endpoint.startswith("api/")
                     ):
                         api_prepended = True
-                        if (
-                            not endpoint.startswith(self._base_url)
-                            and not endpoint.startswith("api/")
-                        ):
-                            url = self._endpoint_to_url(
-                                endpoint, use_rest=True
-                            )
-                            progress.set_destination_url(url)
-                            continue
+                        url = self._endpoint_to_url(endpoint, use_rest=True)
+                        progress.set_source_url(url)
+                        # Endpoint fix is not a failed attempt
+                        attempt -= 1
+                        continue
                     response.raise_for_status()
                     if offset > 0 and response.status_code != 206:
                         # Server ignored 'Range' and sends whole file again,
@@ -1722,7 +1733,7 @@ class ServerAPI(
                 requests.exceptions.ConnectionError,
                 requests.exceptions.ChunkedEncodingError,
             ):
-                if attempt == retries - 1:
+                if attempt >= retries:
                     raise
                 progress.next_attempt()
 
@@ -2127,7 +2138,9 @@ class ServerAPI(
         progress.set_content_size(size)
 
         api_prepended = False
-        for attempt in range(retries):
+        attempt = 0
+        while True:
+            attempt += 1
             try:
                 response = post_func(
                     url,
@@ -2137,22 +2150,27 @@ class ServerAPI(
                     **kwargs
                 )
                 # Auto-fix missing 'api/'
-                if response.status_code in (404, 405) and not api_prepended:
+                if (
+                    response.status_code in (404, 405)
+                    and not api_prepended
+                    and not endpoint.startswith(self._base_url)
+                    and not endpoint.startswith("api/")
+                ):
                     api_prepended = True
-                    if (
-                        not endpoint.startswith(self._base_url)
-                        and not endpoint.startswith("api/")
-                    ):
-                        url = self._endpoint_to_url(endpoint, use_rest=True)
-                        progress.set_destination_url(url)
-                        continue
+                    url = self._endpoint_to_url(endpoint, use_rest=True)
+                    progress.set_destination_url(url)
+                    # Content is sent again and endpoint fix is not a failed
+                    #   attempt
+                    progress.reset_transferred()
+                    attempt -= 1
+                    continue
                 break
 
             except (
                 requests.exceptions.Timeout,
                 requests.exceptions.ConnectionError,
             ):
-                if attempt == retries - 1:
+                if attempt >= retries:
                     raise
                 progress.next_attempt()
                 progress.reset_transferred()

--- a/tests/test_transfer_api_prefix.py
+++ b/tests/test_transfer_api_prefix.py
@@ -1,0 +1,53 @@
+"""Auto-fix of missing 'api/' in transfer endpoints.
+
+Does not require running AYON server.
+"""
+import io
+
+import pytest
+
+from ayon_api.server_api import ServerAPI
+from ayon_api.utils import RequestTypes, TransferProgress
+
+from .fake_transfer import FakeResponse
+
+
+@pytest.fixture
+def con(monkeypatch):
+    monkeypatch.setattr("time.sleep", lambda *args, **kwargs: None)
+    return ServerAPI("http://localhost:0", create_session=False, max_retries=1)
+
+
+def test_download_frontend_page_uses_api_url(con):
+    urls = []
+
+    def get_func(url, **kwargs):
+        urls.append(url)
+        if "/api/" not in url:
+            # Web frontend serves 'index.html' for unknown urls
+            return FakeResponse(200, b"<html>", {"Content-Type": "text/html"})
+        return FakeResponse(200, b"PNG", {"Content-Length": "3"})
+
+    con._base_functions_mapping[RequestTypes.get] = get_func
+    stream = io.BytesIO()
+    con.download_file_to_stream("projects/p/thumbnails/1", stream)
+
+    assert stream.getvalue() == b"PNG"
+    assert urls[-1] == "http://localhost:0/api/projects/p/thumbnails/1"
+
+
+def test_upload_autofix_with_single_attempt_and_progress(con):
+    def put_func(url, data=None, **kwargs):
+        list(data)
+        if "/api/" not in url:
+            return FakeResponse(404)
+        return FakeResponse(200)
+
+    con._base_functions_mapping[RequestTypes.put] = put_func
+    progress = TransferProgress()
+    response = con.upload_file_from_stream(
+        "upload", io.BytesIO(b"0123456789"), progress
+    )
+
+    assert response.status_code == 200
+    assert progress.transferred_size == 10


### PR DESCRIPTION
> Stacked on https://github.com/ynput/ayon-python-api/pull/359 (same download/upload loop). Review only the last commit; the base changes to `develop` once that PR is merged.

## Bug
Transfers try to auto-fix endpoints missing the `api/` prefix (`projects/...` → `api/projects/...`), but:

1. **Downloads save the web frontend HTML as the file.** The server's web frontend answers unknown non-API urls with `200` and `index.html`, so the `404/405` check never triggered. `download_file("projects/<p>/thumbnails/<id>", path)` writes `<!DOCTYPE html>...` instead of the image, without any error.
2. **The fix consumed a retry attempt.** With `max_retries=1` the loop ended right after deciding to fix the url, so the fixed request was never sent (the upload raised the original `404`, the download silently did nothing).
3. **Upload progress doubled.** Content is sent again to the fixed url, but `transferred_size` was not reset (e.g. 20/10 bytes).
4. Download stored the fixed url as destination url (`set_destination_url`) instead of source url.

## Fix
- Also treat a `text/html` success response from a non-API url as a missing `api/` prefix (downloads only; API file endpoints never return HTML).
- Check whether the url can be fixed before marking it as fixed, and use a `while` loop where the endpoint fix does not count as an attempt.
- Reset upload progress when resending to the fixed url; use `set_source_url` for downloads.

## Reproduce
```python
import ayon_api
con = ayon_api.get_server_api_connection()
project_name = "<project>"
thumbnail_id = con.create_thumbnail(project_name, "/path/to/image.png")
con.download_file(f"projects/{project_name}/thumbnails/{thumbnail_id}", "/tmp/out.png")
print(open("/tmp/out.png", "rb").read(15))
# develop: b'<!DOCTYPE html>'
# this PR: b'\x89PNG\r\n\x1a\n...' (and the "Auto-fixed endpoint" warning is logged)
```

## Testing notes
- Snippet above; also with `con.set_max_retries(1)`.
- Endpoints with `api/` behave as before.
- `tests/test_transfer_api_prefix.py` covers the frontend page and upload auto-fix with a single attempt and correct progress.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
