### PR TITLE
Fix failed batch operations printing result and passing silently

### DIFF
--- a/ayon_api/server_api.py
+++ b/ayon_api/server_api.py
@@ -2678,23 +2678,31 @@ class ServerAPI(
         if result.get("success"):
             return None
 
-        print(result)
-        for op_result in result["operations"]:
+        self.log.warning(
+            "Operations failed. Server response:\n%s",
+            json.dumps(result, indent=4, default=str),
+        )
+        for op_result in result.get("operations") or []:
             if op_result["success"]:
                 continue
 
             operation_id = op_result["id"]
             operation = next(
-                op
-                for op in operations_body
-                if op["id"] == operation_id
+                (op for op in operations_body if op["id"] == operation_id),
+                op_result,
             )
             detail = op_result["detail"]
             raise FailedOperations(
                 f"Operation \"{operation_id}\" failed with data:"
-                f"\n{json.dumps(operation, indent=4)}"
+                f"\n{json.dumps(operation, indent=4, default=str)}"
                 f"\nDetail: {detail}."
             )
+
+        # Server did not report which operation failed
+        raise FailedOperations(
+            "Operations failed. Server response:"
+            f"\n{json.dumps(result, indent=4, default=str)}"
+        )
 
     def _prepare_fields(
         self,

--- a/tests/test_operations_result.py
+++ b/tests/test_operations_result.py
@@ -1,0 +1,26 @@
+"""Validation of operations result. Does not require running AYON server."""
+import pytest
+
+from ayon_api.exceptions import FailedOperations
+from ayon_api.server_api import ServerAPI
+
+
+@pytest.fixture
+def con():
+    return ServerAPI("http://localhost:0", create_session=False)
+
+
+def test_failed_result_without_failed_operation_raises(con, capsys):
+    result = {"success": False, "operations": [{"id": "a", "success": True}]}
+    with pytest.raises(FailedOperations, match="Server response"):
+        con._validate_operations_result(result, [{"id": "a"}])
+    assert capsys.readouterr().out == ""
+
+
+def test_failed_operation_raises_with_detail(con):
+    result = {
+        "success": False,
+        "operations": [{"id": "a", "success": False, "detail": "Boom"}],
+    }
+    with pytest.raises(FailedOperations, match="Boom"):
+        con._validate_operations_result(result, [{"id": "a", "type": "x"}])


### PR DESCRIPTION
## Bug
When a batch of operations fails (`send_batch_operations`, `send_background_batch_operations(wait=True)`, `OperationsSession.commit()`):

1. The whole result is `print`ed to stdout — noise in host application consoles and pipelines, not controllable by logging.
2. If the server reports `success: false` but no individual operation as failed, the method returns **without raising**, so the failure is silently ignored.
3. Missing `operations` key or an operation id not found in the sent operations raise `KeyError` / `StopIteration` instead of `FailedOperations`.

## Fix
- Replace `print` with a warning log.
- Raise `FailedOperations` with the server response when no failed operation can be identified.
- Use `.get("operations")` and fall back to the operation result when the sent operation is not found.

## Reproduce
Updating a non-existing folder (does not change any data):
```python
import ayon_api
con = ayon_api.get_server_api_connection()
con.send_batch_operations("<project>", [{
    "type": "update",
    "entityType": "folder",
    "entityId": "0" * 32,
    "data": {"label": "x"},
}])
# develop: the result dict is printed to stdout, then FailedOperations is raised
# this PR: result is logged as a warning, FailedOperations is raised
```

## Testing notes
- Snippet above, check the output goes through logging (e.g. silence it with `logging.getLogger(con.log.name).setLevel(logging.ERROR)`).
- `tests/test_operations_result.py` covers the silent failure case.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
